### PR TITLE
Allow fallback to name when FuncName not present in functiondelete/li…

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -466,8 +466,12 @@ class DenonAVR(object):
                 child.find("rename").text.strip())
 
         for child in root.findall("./cmd/functiondelete/list"):
-            deleted_sources[child.find("FuncName").text.strip()] = "DEL" if (
-                child.find("use").text.strip() == "0") else None
+            if child.find("FuncName") is not None:
+                deleted_sources[
+                    child.find("FuncName").text.strip()] = "DEL" if (child.find("use").text.strip() == "0") else None
+            else:
+                deleted_sources[
+                    child.find("name").text.strip()] = "DEL" if (child.find("use").text.strip() == "0") else None
 
         return (renamed_sources, deleted_sources, True)
 


### PR DESCRIPTION
Allow fallback to name when FuncName not present in functiondelete/list XML body. This is (for example) the case on the Marantz SR6008 AVR. The issue was seen by a couple of people in the home-assistant project (https://github.com/home-assistant/home-assistant/issues/7493)

Tried to do it in a oneliner, but that didn't really help code readability, so created a regular if/else structure.

Example XML retrieved from my AVR below. Note that the 'Blu-ray' input does not have a ```FuncName``` in the ```functiondelete``` list

```xml
<?xml version="1.0" encoding="utf-8" ?>
<rx>
  <cmd>
    <functionrename>
      <list>
        <name>TUNER</name>
        <rename>TUNER</rename>
      </list>
      <list>
        <name>CD</name>
        <rename>Sonos       </rename>
      </list>
      <list>
        <name>PHONO</name>
        <rename>PHONO       </rename>
      </list>
      <list>
        <name>M-XPORT</name>
        <rename>M-XPort     </rename>
      </list>
      <list>
        <name>NETWORK</name>
        <rename>NETWORK</rename>
      </list>
      <list>
        <name>DVD</name>
        <rename>DVD         </rename>
      </list>
      <list>
        <name>Blu-ray</name>
        <rename>Blu-ray     </rename>
      </list>
      <list>
        <name>TV AUDIO</name>
        <rename>TV Audio    </rename>
      </list>
      <list>
        <name>CBL/SAT</name>
        <rename>Horizon     </rename>
      </list>
      <list>
        <name>GAME</name>
        <rename>Steam Link  </rename>
      </list>
      <list>
        <name>AUX1</name>
        <rename>AUX1        </rename>
      </list>
      <list>
        <name>AUX2</name>
        <rename>AUX2        </rename>
      </list>
      <list>
        <name>Media Player</name>
        <rename>Apple TV    </rename>
      </list>
      <list>
        <name>iPod/USB</name>
        <rename>iPod/USB</rename>
      </list>
    </functionrename>
  </cmd>
  <cmd>
    <functiondelete>
      <list>
        <name>TUNER</name>
        <FuncName>TUNER</FuncName>
        <use>0</use>
      </list>
      <list>
        <name>CD</name>
        <FuncName>CD</FuncName>
        <use>1</use>
      </list>
      <list>
        <name>PHONO</name>
        <FuncName>PHONO</FuncName>
        <use>0</use>
      </list>
      <list>
        <name>M-XPort</name>
        <FuncName>M-XPort</FuncName>
        <use>0</use>
      </list>
      <list>
        <name>NETWORK</name>
        <FuncName>NETWORK</FuncName>
        <use>1</use>
      </list>
      <list>
        <name>DVD</name>
        <FuncName>DVD</FuncName>
        <use>0</use>
      </list>
      <list>
        <name>Blu-ray</name>
        <use>0</use>
      </list>
      <list>
        <name>TV AUDIO</name>
        <FuncName>TV AUDIO</FuncName>
        <use>0</use>
      </list>
      <list>
        <name>CBL/SAT</name>
        <FuncName>CBL/SAT</FuncName>
        <use>1</use>
      </list>
      <list>
        <name>GAME</name>
        <FuncName>GAME</FuncName>
        <use>1</use>
      </list>
      <list>
        <name>AUX1</name>
        <FuncName>AUX1</FuncName>
        <use>0</use>
      </list>
      <list>
        <name>AUX2</name>
        <FuncName>AUX2</FuncName>
        <use>0</use>
      </list>
      <list>
        <name>Media Player</name>
        <FuncName>Media Player</FuncName>
        <use>1</use>
      </list>
      <list>
        <name>iPod/USB</name>
        <FuncName>iPod/USB</FuncName>
        <use>0</use>
      </list>
    </functiondelete>
  </cmd>
</rx>
```