### PR TITLE
Try to detect error string in body

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -452,6 +452,9 @@ class DenonAVR(object):
         # Buffered XML not needed anymore: close
         body.close()
 
+        if 'Access Error: Data follows' in res:
+            return (renamed_sources, deleted_sources, False)
+
         try:
             # Return XML ElementTree
             root = ET.fromstring(res)


### PR DESCRIPTION
The AVR-1912 returns 200 OK on POST to /goform/AppCommand.xml, but with
a error in the body.

Before this patch, that error was missed and a empty mapping for
renamed_sources and deleted_sources was returned, togeather with a
status of True, so _get_renamed_deleted_sources was never run.