### PR TITLE
Add Marantz SSDP discovery

### DIFF
--- a/denonavr/ssdp.py
+++ b/denonavr/ssdp.py
@@ -56,6 +56,7 @@ SCPD_PRESENTATIONURL = "{xmlns}presentationURL".format(xmlns=SCPD_XMLNS)
 
 DEVICETYPE_DENON = "urn:schemas-upnp-org:device:MediaRenderer:1"
 
+SUPPORTED_MANUFACTURERS = ["Denon", "Marantz"]
 
 def identify_denonavr_receivers():
     """
@@ -161,7 +162,7 @@ def evaluate_scpd_xml(url):
             _LOGGER.debug("Device %s has manufacturer %s", url,
                           root.find(SCPD_DEVICE).find(SCPD_MANUFACTURER).text)
             if (root.find(SCPD_DEVICE).find(
-                    SCPD_MANUFACTURER).text == "Denon" and root.find(
+                    SCPD_MANUFACTURER).text in SUPPORTED_MANUFACTURERS and root.find(
                         SCPD_DEVICE).find(
                             SCPD_DEVICETYPE).text == DEVICETYPE_DENON):
                 device = {}

--- a/denonavr/ssdp.py
+++ b/denonavr/ssdp.py
@@ -162,9 +162,9 @@ def evaluate_scpd_xml(url):
             _LOGGER.debug("Device %s has manufacturer %s", url,
                           root.find(SCPD_DEVICE).find(SCPD_MANUFACTURER).text)
             if (root.find(SCPD_DEVICE).find(
-                    SCPD_MANUFACTURER).text in SUPPORTED_MANUFACTURERS and root.find(
-                        SCPD_DEVICE).find(
-                            SCPD_DEVICETYPE).text == DEVICETYPE_DENON):
+                    SCPD_MANUFACTURER).text in SUPPORTED_MANUFACTURERS and
+                    root.find(SCPD_DEVICE).find(
+                        SCPD_DEVICETYPE).text == DEVICETYPE_DENON):
                 device = {}
                 device["host"] = urlparse(
                     root.find(SCPD_DEVICE).find(


### PR DESCRIPTION
The denonavr Library also works for Marantz AVR, since they share the same XML API (at least as far as I know). I have tested this with with my Marantz NR 1604 and it works without problems.

I have added a small patch to enable automatic device discovery via SSDP for both, Denon and Marantz receivers.