### PR TITLE
Add Marantz NETWORK audio source

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -33,7 +33,7 @@ PLAYING_SOURCES = ("Online Music", "Media Server", "iPod/USB", "Bluetooth",
                    "HD Radio", "TUNER", "NET/USB", "HDRADIO", "Music Server")
 NETAUDIO_SOURCES = ("Online Music", "Media Server", "iPod/USB", "Bluetooth",
                     "Internet Radio", "Favorites", "Spotify", "Flickr",
-                    "NET/USB", "Music Server")
+                    "NET/USB", "Music Server", "NETWORK")
 
 APPCOMMAND_URL = "/goform/AppCommand.xml"
 STATUS_URL = "/goform/formMainZone_MainZoneXmlStatus.xml"


### PR DESCRIPTION
This fixes problems with home assistant not reporting the device as playing when playing internet radio.