### PR TITLE
Treat Marantz SR6008 as AVR-X device

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -20,7 +20,7 @@ import requests
 
 _LOGGER = logging.getLogger("DenonAVR")
 
-DEVICEINFO_AVR_X_PATTERN = r"(.*AVR-X.*|.*SR500[6-9]|.*NR1604)"
+DEVICEINFO_AVR_X_PATTERN = r"(.*AVR-X.*|.*SR500[6-9]|.*SR6008|.*NR1604)"
 
 SOURCE_MAPPING = {"TV AUDIO": "TV", "iPod/USB": "USB/IPOD", "Bluetooth": "BT",
                   "Blu-ray": "BD", "CBL/SAT": "SAT/CBL", "NETWORK": "NET",


### PR DESCRIPTION
Similar to the change to include Marantz SR5006 as AVR-X device, also include Marantz SR6008. This prevents "No mapping for source MPLAY" errors.