### PR TITLE
Add MANIFEST.in so that tests are included in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+exclude .*
+exclude MANIFEST.in
+graft tests
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
Hi,
I checked the source and I don't see where pytest-* is required. I also added a MANIFEST.in file because the PyPI distributions currently do not contain the tests. Adding them makes it easier for distributions that rely on PyPI download sources and run tests.