### PR TITLE
Added sound mode support

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -38,12 +38,14 @@ CHANGE_INPUT_MAPPING = {"Internet Radio": "IRP", "Online Music": "NET",
                         "Flickr": "FLICKR", "Favorites": "FAVORITES"}
 
 SOUND_MODE_MAPPING = OrderedDict([('MUSIC', ['PLII MUSIC']),
-                                  ('MOVIE', ['PLII MOVIE']),
+                                  ('MOVIE', ['PLII MOVIE','PLII CINEMA',
+                                             'DTS NEO:X CINEMA']),
                                   ('GAME', ['PLII GAME']),
                                   ('PURE DIRECT', ['DIRECT']),
                                   ('AUTO', ['None']),
                                   ('DOLBY DIGITAL', ['DOLBY DIGITAL']),
-                                  ('MCH STEREO', ['MULTI CH STEREO']),
+                                  ('MCH STEREO', ['MULTI CH STEREO',
+                                                  'MULTI CH IN']),
                                   ('STEREO', ['STEREO'])])
 
 PLAYING_SOURCES = ("Online Music", "Media Server", "iPod/USB", "Bluetooth",

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -37,7 +37,7 @@ CHANGE_INPUT_MAPPING = {"Internet Radio": "IRP", "Online Music": "NET",
                         "Media Server": "SERVER", "Spotify": "SPOTIFY",
                         "Flickr": "FLICKR", "Favorites": "FAVORITES"}
 
-SOUND_MODE_MAPPING = OrderedDict(\
+SOUND_MODE_MAPPING = OrderedDict(
     [('MUSIC', ['PLII MUSIC', 'DTS NEO:6 MUSIC', 'DOLBY D +NEO:X M',
                 'ROCK ARENA', 'JAZZ CLUB', 'MATRIX']),
      ('MOVIE', ['PLII MOVIE', 'PLII CINEMA', 'DTS NEO:X CINEMA',

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -37,18 +37,18 @@ CHANGE_INPUT_MAPPING = {"Internet Radio": "IRP", "Online Music": "NET",
                         "Media Server": "SERVER", "Spotify": "SPOTIFY",
                         "Flickr": "FLICKR", "Favorites": "FAVORITES"}
 
-SOUND_MODE_MAPPING = OrderedDict\
-([('MUSIC', ['PLII MUSIC', 'DTS NEO:6 MUSIC', 'DOLBY D +NEO:X M',
-             'ROCK ARENA', 'JAZZ CLUB', 'MATRIX']),
-  ('MOVIE', ['PLII MOVIE', 'PLII CINEMA', 'DTS NEO:X CINEMA',
-             'DTS NEO:6 CINEMA', 'DOLBY D +NEO:X C', 'MONO MOVIE']),
-  ('GAME', ['PLII GAME', 'DOLBY D +NEO:X G', 'VIDEO GAME']),
-  ('AUTO', ['None']),
-  ('VIRTUAL', ['VIRTUAL']),
-  ('PURE DIRECT', ['DIRECT']),
-  ('DOLBY DIGITAL', ['DOLBY DIGITAL', 'DOLBY D + DOLBY SURROUND']),
-  ('MCH STEREO', ['MULTI CH STEREO', 'MULTI CH IN']),
-  ('STEREO', ['STEREO'])])
+SOUND_MODE_MAPPING = OrderedDict(\
+    [('MUSIC', ['PLII MUSIC', 'DTS NEO:6 MUSIC', 'DOLBY D +NEO:X M',
+                'ROCK ARENA', 'JAZZ CLUB', 'MATRIX']),
+     ('MOVIE', ['PLII MOVIE', 'PLII CINEMA', 'DTS NEO:X CINEMA',
+                'DTS NEO:6 CINEMA', 'DOLBY D +NEO:X C', 'MONO MOVIE']),
+     ('GAME', ['PLII GAME', 'DOLBY D +NEO:X G', 'VIDEO GAME']),
+     ('AUTO', ['None']),
+     ('VIRTUAL', ['VIRTUAL']),
+     ('PURE DIRECT', ['DIRECT']),
+     ('DOLBY DIGITAL', ['DOLBY DIGITAL', 'DOLBY D + DOLBY SURROUND']),
+     ('MCH STEREO', ['MULTI CH STEREO', 'MULTI CH IN']),
+     ('STEREO', ['STEREO'])])
 
 PLAYING_SOURCES = ("Online Music", "Media Server", "iPod/USB", "Bluetooth",
                    "Internet Radio", "Favorites", "SpotifyConnect", "Flickr",
@@ -1284,7 +1284,7 @@ class DenonAVR(object):
         # sent command
         try:
             if self.send_get_command(command_url):
-                self.sound_mode() = sound_mode
+                self._sound_mode_raw = self._sound_mode_dict[sound_mode][0]
                 return True
             else:
                 return False

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1145,12 +1145,18 @@ class DenonAVR(object):
 
     @property
     def sound_mode_dict(self):
-        """Return a dictionary of available sound modes with their mapping values."""
+        """
+        Return a dictionary of available sound modes
+        with their mapping values.
+        """
         return self._sound_mode_dict
 
     @property
     def SM_match_dict(self):
-        """Return a dictionary that is used to map each sound_mode_raw to it's matched sound_mode."""
+        """
+        Return a dictionary that is used to 
+        map each sound_mode_raw to it's matched sound_mode.
+        """
         return self._SM_match_dict
 
     @property
@@ -1296,7 +1302,8 @@ class DenonAVR(object):
     def set_sound_mode_dict(self, sound_mode_dict):
         Error_msg = ("Syntax of sound mode dictionary not valid, "
                      "use: OrderedDict([('COMMAND', ['VALUE1','VALUE2'])])")
-        if (type(sound_mode_dict) == OrderedDict or type(sound_mode_dict) == dict):
+        if (type(sound_mode_dict) == OrderedDict or\
+            type(sound_mode_dict) == dict):
             mode_list = list(sound_mode_dict.values())
             for sublist in mode_list:
                 if type(sublist) == list:

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1288,8 +1288,8 @@ class DenonAVR(object):
             return False
 
     def set_sound_mode_dict(self, sound_mode_dict):
-        Error_msg = "Syntax of sound mode dictionary not valid, "
-                    "use: OrderedDict([('COMMAND', ['VALUE1','VALUE2'])])"
+        Error_msg = ("Syntax of sound mode dictionary not valid, "
+                    "use: OrderedDict([('COMMAND', ['VALUE1','VALUE2'])])")
         if type(sound_mode_dict) == OrderedDict:
             mode_list = list(sound_mode_dict.values())
             for sublist in mode_list:

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -232,8 +232,6 @@ class DenonAVR(object):
         self._input_func = None
         self._input_func_list = {}
         self._input_func_list_rev = {}
-        self._sound_mode = None
-        self._sound_mode_match_warning = False
         self._sound_mode_raw = None
         self._sound_mode_dict = SOUND_MODE_MAPPING
         self._netaudio_func_list = []
@@ -1053,9 +1051,7 @@ class DenonAVR(object):
                 self._name = child[0].text
                 relevant_tags.pop(child.tag, None)
             elif (child.tag == "selectSurround" or child.tag == "SurrMode"):
-                sound_mode_raw = child[0].text.rstrip()
-                self._sound_mode = self.match_sound_mode(sound_mode_raw)
-                self._sound_mode_raw = sound_mode_raw
+                self._sound_mode_raw = child[0].text.rstrip()
                 if "selectSurround" in relevant_tags.keys():
                     relevant_tags.pop("selectSurround", None)
                 if "SurrMode" in relevant_tags.keys():
@@ -1138,10 +1134,8 @@ class DenonAVR(object):
     @property
     def sound_mode(self):
         """Return the matched current sound mode as a string."""
-        if self._sound_mode_match_warning:
-            _LOGGER.warning("Not able to match sound mode, "
-                            "returning raw sound mode.")
-        return self._sound_mode
+        sound_mode_matched = self.match_sound_mode(self._sound_mode_raw)
+        return sound_mode_matched
 
     @property
     def sound_mode_list(self):
@@ -1320,11 +1314,11 @@ class DenonAVR(object):
                 if sound_mode_raw.upper() in sublist:
                     mode_index = mode_list.index(sublist)
                     sound_mode = list(self._sound_mode_dict.keys())[mode_index]
-                    self._sound_mode_match_warning = False
                     return sound_mode
         except ValueError:
             pass
-        self._sound_mode_match_warning = True
+        _LOGGER.warning("Not able to match sound mode, "
+                        "returning raw sound mode.")
         return sound_mode_raw
 
     def toggle_play_pause(self):

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1154,7 +1154,7 @@ class DenonAVR(object):
     @property
     def SM_match_dict(self):
         """
-        Return a dictionary that is used to 
+        Return a dictionary that is used to
         map each sound_mode_raw to it's matched sound_mode.
         """
         return self._SM_match_dict
@@ -1302,18 +1302,18 @@ class DenonAVR(object):
     def set_sound_mode_dict(self, sound_mode_dict):
         Error_msg = ("Syntax of sound mode dictionary not valid, "
                      "use: OrderedDict([('COMMAND', ['VALUE1','VALUE2'])])")
-        if (type(sound_mode_dict) == OrderedDict or\
+        if (type(sound_mode_dict) == OrderedDict or
             type(sound_mode_dict) == dict):
-            mode_list = list(sound_mode_dict.values())
-            for sublist in mode_list:
-                if type(sublist) == list:
-                    for element in sublist:
-                        if type(element) != str:
-                            _LOGGER.error(Error_msg)
-                            return False
-                else:
-                    _LOGGER.error(Error_msg)
-                    return False
+                mode_list = list(sound_mode_dict.values())
+                for sublist in mode_list:
+                    if type(sublist) == list:
+                        for element in sublist:
+                            if type(element) != str:
+                                _LOGGER.error(Error_msg)
+                                return False
+                    else:
+                        _LOGGER.error(Error_msg)
+                        return False
         else:
             _LOGGER.error(Error_msg)
             return False

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1149,7 +1149,7 @@ class DenonAVR(object):
         return self._sound_mode_dict
 
     @property
-    def sound_mode_match_dict(self):
+    def SM_match_dict(self):
         """Return a dictionary that is used to map each sound_mode_raw to it's matched sound_mode."""
         return self._SM_match_dict
 
@@ -1314,7 +1314,7 @@ class DenonAVR(object):
         self._SM_match_dict = self.construct_SM_match_dict(sound_mode_dict)
         return True
 
-    def construct_SM_match_dic(self, sound_mode_dict):
+    def construct_SM_match_dict(self, sound_mode_dict):
         mode_dict = list(sound_mode_dict.items())
         match_mode_dict = {}
         for matched_mode, sublist in mode_dict:

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -386,7 +386,8 @@ class DenonAVR(object):
         # pylint: disable=too-many-branches,too-many-statements
         # Set all tags to be evaluated
         relevant_tags = {"Power": None, "InputFuncSelect": None, "Mute": None,
-                         "MasterVolume": None, "selectSurround": None, "SurrMode": None}
+                         "MasterVolume": None, "selectSurround": None,
+                         "SurrMode": None}
 
         # Get status XML from Denon receiver via HTTP
         try:
@@ -1287,7 +1288,8 @@ class DenonAVR(object):
             return False
 
     def set_sound_mode_dict(self, sound_mode_dict):
-        Error_msg = "Syntax of sound mode dictionary not valid, use: OrderedDict([('COMMAND', ['VALUE1','VALUE2'])])"
+        Error_msg = "Syntax of sound mode dictionary not valid, "
+                    "use: OrderedDict([('COMMAND', ['VALUE1','VALUE2'])])"
         if type(sound_mode_dict) == OrderedDict:
             mode_list = list(sound_mode_dict.values())
             for sublist in mode_list:
@@ -1302,7 +1304,6 @@ class DenonAVR(object):
         else:
             _LOGGER.error(Error_msg)
             return False
-        
         self._sound_mode_dict = sound_mode_dict
         return True
 
@@ -1316,7 +1317,8 @@ class DenonAVR(object):
                     return sound_mode
         except ValueError:
             pass
-        _LOGGER.warning("Not able to match sound mode, returning raw sound mode.")
+        _LOGGER.warning("Not able to match sound mode, "
+                        "returning raw sound mode.")
         return sound_mode_raw
 
     def toggle_play_pause(self):

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -37,7 +37,7 @@ CHANGE_INPUT_MAPPING = {"Internet Radio": "IRP", "Online Music": "NET",
                         "Media Server": "SERVER", "Spotify": "SPOTIFY",
                         "Flickr": "FLICKR", "Favorites": "FAVORITES"}
 
-SOUND_MODE_MAPPING = OrderedDict \
+SOUND_MODE_MAPPING = OrderedDict\
   ([('MUSIC', ['PLII MUSIC', 'DTS NEO:6 MUSIC', 'DOLBY D +NEO:X M',
                'ROCK ARENA', 'JAZZ CLUB', 'MATRIX']),
     ('MOVIE', ['PLII MOVIE', 'PLII CINEMA', 'DTS NEO:X CINEMA',

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -231,6 +231,7 @@ class DenonAVR(object):
         self._input_func_list = {}
         self._input_func_list_rev = {}
         self._sound_mode = None
+        self._sound_mode_match_warning = False
         self._sound_mode_raw = None
         self._sound_mode_dict = SOUND_MODE_MAPPING
         self._netaudio_func_list = []
@@ -1135,6 +1136,9 @@ class DenonAVR(object):
     @property
     def sound_mode(self):
         """Return the matched current sound mode as a string."""
+        if self._sound_mode_match_warning:
+            _LOGGER.warning("Not able to match sound mode, "
+                            "returning raw sound mode.")
         return self._sound_mode
 
     @property
@@ -1314,11 +1318,11 @@ class DenonAVR(object):
                 if sound_mode_raw.upper() in sublist:
                     mode_index = mode_list.index(sublist)
                     sound_mode = list(self._sound_mode_dict.keys())[mode_index]
+                    self._sound_mode_match_warning = False
                     return sound_mode
         except ValueError:
             pass
-        _LOGGER.warning("Not able to match sound mode, "
-                        "returning raw sound mode.")
+        self._sound_mode_match_warning = True
         return sound_mode_raw
 
     def toggle_play_pause(self):

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -37,16 +37,18 @@ CHANGE_INPUT_MAPPING = {"Internet Radio": "IRP", "Online Music": "NET",
                         "Media Server": "SERVER", "Spotify": "SPOTIFY",
                         "Flickr": "FLICKR", "Favorites": "FAVORITES"}
 
-SOUND_MODE_MAPPING = OrderedDict([('MUSIC', ['PLII MUSIC']),
-                                  ('MOVIE', ['PLII MOVIE', 'PLII CINEMA',
-                                             'DTS NEO:X CINEMA']),
-                                  ('GAME', ['PLII GAME']),
-                                  ('PURE DIRECT', ['DIRECT']),
-                                  ('AUTO', ['None']),
-                                  ('DOLBY DIGITAL', ['DOLBY DIGITAL']),
-                                  ('MCH STEREO', ['MULTI CH STEREO',
-                                                  'MULTI CH IN']),
-                                  ('STEREO', ['STEREO'])])
+SOUND_MODE_MAPPING = OrderedDict \
+  ([('MUSIC', ['PLII MUSIC', 'DTS NEO:6 MUSIC', 'DOLBY D +NEO:X M',
+               'ROCK ARENA', 'JAZZ CLUB', 'MATRIX']),
+    ('MOVIE', ['PLII MOVIE', 'PLII CINEMA', 'DTS NEO:X CINEMA',
+               'DTS NEO:6 CINEMA', 'DOLBY D +NEO:X C', 'MONO MOVIE']),
+    ('GAME', ['PLII GAME', 'DOLBY D +NEO:X G', 'VIDEO GAME']),
+    ('AUTO', ['None']),
+    ('VIRTUAL', ['VIRTUAL']),
+    ('PURE DIRECT', ['DIRECT']),
+    ('DOLBY DIGITAL', ['DOLBY DIGITAL', 'DOLBY D + DOLBY SURROUND']),
+    ('MCH STEREO', ['MULTI CH STEREO', 'MULTI CH IN']),
+    ('STEREO', ['STEREO'])])
 
 PLAYING_SOURCES = ("Online Music", "Media Server", "iPod/USB", "Bluetooth",
                    "Internet Radio", "Favorites", "SpotifyConnect", "Flickr",
@@ -1052,10 +1054,8 @@ class DenonAVR(object):
                 relevant_tags.pop(child.tag, None)
             elif (child.tag == "selectSurround" or child.tag == "SurrMode"):
                 self._sound_mode_raw = child[0].text.rstrip()
-                if "selectSurround" in relevant_tags.keys():
-                    relevant_tags.pop("selectSurround", None)
-                if "SurrMode" in relevant_tags.keys():
-                    relevant_tags.pop("SurrMode", None)
+                relevant_tags.pop("selectSurround", None)
+                relevant_tags.pop("SurrMode", None)
 
         return relevant_tags
 

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -38,7 +38,7 @@ CHANGE_INPUT_MAPPING = {"Internet Radio": "IRP", "Online Music": "NET",
                         "Flickr": "FLICKR", "Favorites": "FAVORITES"}
 
 SOUND_MODE_MAPPING = OrderedDict([('MUSIC', ['PLII MUSIC']),
-                                  ('MOVIE', ['PLII MOVIE','PLII CINEMA',
+                                  ('MOVIE', ['PLII MOVIE', 'PLII CINEMA',
                                              'DTS NEO:X CINEMA']),
                                   ('GAME', ['PLII GAME']),
                                   ('PURE DIRECT', ['DIRECT']),

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1289,7 +1289,7 @@ class DenonAVR(object):
 
     def set_sound_mode_dict(self, sound_mode_dict):
         Error_msg = ("Syntax of sound mode dictionary not valid, "
-                    "use: OrderedDict([('COMMAND', ['VALUE1','VALUE2'])])")
+                     "use: OrderedDict([('COMMAND', ['VALUE1','VALUE2'])])")
         if type(sound_mode_dict) == OrderedDict:
             mode_list = list(sound_mode_dict.values())
             for sublist in mode_list:


### PR DESCRIPTION
new functions to use:
- denonavr.sound_mode (gives the current matched sound mode (after an denonavr.update))
- denonavr.sound_mode_raw (gives the current sound mode as received from the AVR (after an denonavr.update))
- denonavr.sound_mode_list (gives a list of supported sound mode commands)
- denonavr.sound_mode_dict (gives the full dictionarry containing all supported commands including their matching values)
- denonavr.set_sound_mode(VALUE) (change the sound mode of the AVR using one of the VALUE's of the denonavr.sound_mode_list)
- denonavr.set_sound_mode_dict (change the matching sound mode dict, this will throw an error if the wrong syntax is used with an example of a correct syntax)