### PR TITLE
Add 'Dolby TrueHD' sound mode

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -53,7 +53,7 @@ SOUND_MODE_MAPPING = OrderedDict(
                         'MULTI IN + NEURAL:X', 'DOLBY D + NEURAL:X',
                         'DOLBY DIGITAL + NEURAL:X',
                         'DOLBY DIGITAL + + NEURAL:X',
-                        'DOLBY AUDIO - DOLBY SURROUND']),
+                        'DOLBY AUDIO - DOLBY SURROUND', 'DOLBY TRUEHD']),
      ('DTS SURROUND', ['DTS SURROUND', 'DTS NEURAL:X', 'STANDARD(DTS)',
                        'DTS + NEURAL:X', 'MULTI CH IN', 'DTS-HD MSTR',
                        'DTS VIRTUAL:X']),


### PR DESCRIPTION
Log from HA 0.92:
```
2019-04-29 11:45:24 WARNING (SyncWorker_17) [DenonAVR] Not able to match sound mode: 'Dolby TrueHD', returning raw sound mode.
```