### PR TITLE
Input and validation scheme for XML commands.

### DIFF
--- a/denonavr/commands.py
+++ b/denonavr/commands.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module contains instances of the XmlCommand class that are representations
+of the Denon AVR 2016 XML command structure.  Refer to ./XML_data_dump.txt for
+more information or to find out how to sniff commands on your own AVR.
+"""
+from .helpers import XmlCommand1, XmlCommand3
+
+SET_DYNAMIC_VOL = XmlCommand3(
+    "Dynamic Volume", "SetAudyssey",
+    (0, 3), param="dynamicvol",
+    values=[
+        "Off",
+        "Light",
+        "Medium",
+        "Heavy"]
+)

--- a/denonavr/helpers.py
+++ b/denonavr/helpers.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Classes and functions for denonavr.
+"""
+
+import xml.etree.ElementTree as ET
+import logging
+import re
+
+class XmlCommand1:
+    """
+    This class is a representation of XML commands from the Denon AVR 2016 App.
+    The commands all have cmd_id=1 and AppCommand.xml as endpoint.
+    """
+    def __init__(self, friendly_name, cmd_id_text, bounds, name=None,
+                 values=None):
+        """
+        The constructor for the XmlCommand1 class.
+
+        Attributes:
+
+            friendly_name (string): The friendly name of the command.
+            cmd_id_text (string): text between <cmd id=1> and </cmd>
+            bounds (tuple(int, int)): the (lower, upper) bounds of the command.
+            name (string): The paramater name according to Denon API, defaults to
+                None.
+            values (list ["string"]): A list indexed by the integer value expected by
+                the Denon API containing the friendly names associated with each
+                value. For example ["Off", "On"]. Defaults to None.
+
+        If the values attribute was provided then the constructor will
+        translate those fields into a dictionary so that the integer value can
+        be accessed by referring to the friendly name of the command.
+        """
+        self.friendly_name = friendly_name
+        self.cmd_id = "1"
+        self.cmd_id_text = cmd_id_text
+        self.bounds = bounds
+        self.name = name
+        self.values = values
+
+        if values:
+            self.value_dict = {}
+            for number, key in enumerate(self.values):
+                self.value_dict[key] = str(number)
+
+        elif bounds[0] is 0 and bounds[1] is 48:
+            self.value_dict = {}
+            decibel = -12
+            for number in range(49):
+                if number % 2 is 0:
+                    key = str(int(decibel)) + "dB"
+                else:
+                    key = str(decibel) + "dB"
+                self.value_dict[key] = str(number)
+                decibel += 0.5
+
+
+class XmlCommand3:
+    """
+    This class is a representation of XML commands from the Denon AVR 2016 App.
+    The commands all have cmd_id=3 and AppCommand0300.xml as endpoint.
+    """
+    def __init__(self, friendly_name, name, bounds, param=None, values=None):
+        """
+        The constructor for the XmlCommand3 class.
+
+        Attributes:
+
+            friendly_name (string): The friendly name of the command.
+            name (string): name according to Denon API.
+            bounds (tuple(int, int)): the (lower, upper) bounds of the command.
+            param (string): The paramater name according to Denon API, defaults to
+                None.
+            values (list[strings]): A list indexed by the integer value expected by
+                the Denon API containing the friendly names associated with each
+                value. For example ["Off", "On"]. Defaults to None.
+
+        If the values attribute was provided then the constructor will
+        translate those fields into a dictionary so that the integer value can
+        be accessed by referring to the friendly name of the command.
+        """
+        self.friendly_name = friendly_name
+        self.cmd_id = "3"
+        self.name = name
+        self.bounds = bounds
+        self.param = param
+        self.values = values
+
+        if values:
+            self.value_dict = {}
+            for number, key in enumerate(self.values):
+                self.value_dict[key] = str(number)
+
+        elif bounds[0] is 0 and bounds[1] is 48:
+            self.value_dict = {}
+            decibel = -12
+            for number in range(49):
+                if number % 2 is 0:
+                    key = str(int(decibel)) + "dB"
+                else:
+                    key = str(decibel) + "dB"
+                self.value_dict[key] = str(number)
+                decibel += 0.5
+
+
+def make_xml_command(command, value, zone=None):
+    """
+    Package a command and value into XML for the Denon API.
+
+    Args:
+        command (XmlCommand): An instance of the XmlCommand1 or XmlCommand3
+            class.
+        value (string): The value that the command is to bet set to.
+        zone (string): The zone to apply the command to. Defalts to None.
+            Valid entries: "Main" "Zone1" Zone2" etc.
+
+    Returns:
+        bytes: UTF-8 encoded XML with header ready to POST.
+    """
+    xml_root = ET.Element("tx")
+    xml_cmd_id = ET.SubElement(xml_root, "cmd",
+                               {"id": command.cmd_id})
+
+    if command.cmd_id is "1": #AppCommand.xml endpoint
+        xml_cmd_id.text = command.cmd_id_text
+        if command.name:
+            xml_name = ET.SubElement(xml_root, "name")
+            xml_name.text = command.name
+        if zone:
+            xml_zone = ET.SubElement(xml_root, "zone")
+            xml_zone.text = zone
+        xml_value = ET.SubElement(xml_root, "value")
+
+    elif command.cmd_id is "3": #AppCommand0300.xml endpoint
+        xml_name = ET.SubElement(xml_cmd_id, "name")
+        xml_name.text = command.name
+
+        if command.param:
+            xml_list = ET.SubElement(xml_cmd_id, "list")
+            xml_value = ET.SubElement(xml_list, "param",
+                                      {"name": command.param})
+        else:
+            xml_value = ET.SubElement(xml_cmd_id, "value")
+
+    try:
+        xml_value.text = command.value_dict[value]
+    except (AttributeError, KeyError):
+        try:
+            if re.match(r'-?\d+\Z', str(value)):
+                value = int(value)
+            if value >= command.bounds[0] and\
+                value <= command.bounds[1]:
+                xml_value.text = str(value)
+            elif value <= command.bounds[0]:
+                xml_value.text = str(command.bounds[0])
+                logging.warning(
+                    "Value too low, clipped to %d.", command.bounds[0])
+            elif value >= command.bounds[1]:
+                xml_value.text = str(command.bounds[1])
+                logging.warning(
+                    "Value too high, clipped to %d.", command.bounds[1])
+        except TypeError:
+            valid = ", ".join(key for key in command.value_dict)
+            logging.error(
+                "Value not in value_dict. Valid keys are: %s", valid)
+            return
+
+    temp = ET.tostring(xml_root)
+    xml = b"<?xml version=\\'1.0\\' encoding=\\'utf8\\'?>\\n"
+    payload = xml + temp
+    return payload.decode('utf-8')

--- a/tests/test_xml_commands.py
+++ b/tests/test_xml_commands.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Test make_xml_command.py
+"""
+
+import sys
+import unittest
+import logging
+from denonavr.helpers import make_xml_command, XmlCommand1, XmlCommand3
+
+logger = logging.getLogger()
+logger.level = logging.DEBUG
+
+SET_DYNAMIC_VOL = XmlCommand3(
+    "Dynamic Volume", "SetAudyssey",
+    (0, 3), param="dynamicvol",
+    values=[
+        "Off",
+        "Light",
+        "Medium",
+        "Heavy"]
+)
+SET_LFE = XmlCommand3(
+    "LFE Level", "SetSurroundParameter",
+    (-10, 0), param="lfe") #left values field blank
+SET_CENTER_LEVEL = XmlCommand1(
+    "Center Level", "SetChLevel",
+    (0, 48), name="C"
+)
+SET_DIALOG_LEVEL = XmlCommand1(
+    "Dialog Level", "SetDialogLevel",
+    (0, 48)
+)
+
+class TestXmlCommands(unittest.TestCase):
+
+#------------------------------------------------------------------------------
+#   DICTIONARY LOOKUP
+
+    def test_dict(self):
+        """
+        Test the friendly_name to integer value conversion.
+        """
+        self.assertEqual(make_xml_command(SET_DYNAMIC_VOL, "Off"),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetAudyssey</name><list>\
+<param name="dynamicvol">0</param></list></cmd></tx>')
+
+        self.assertEqual(make_xml_command(SET_DYNAMIC_VOL, "Light"),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetAudyssey</name><list>\
+<param name="dynamicvol">1</param></list></cmd></tx>')
+
+        self.assertEqual(make_xml_command(SET_DYNAMIC_VOL, "Medium"),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetAudyssey</name><list>\
+<param name="dynamicvol">2</param></list></cmd></tx>')
+
+        self.assertEqual(make_xml_command(SET_DYNAMIC_VOL, "Heavy"),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetAudyssey</name><list>\
+<param name="dynamicvol">3</param></list></cmd></tx>')
+
+#------------------------------------------------------------------------------
+#   ERROR HANDLING
+
+#   Let the appropriate log messages through to console
+    stream_handler = logging.StreamHandler(sys.stdout)
+    logger.addHandler(stream_handler)
+    logger.removeHandler(stream_handler)
+
+    def test_error_handling(self):
+        """
+        Test the Try/Except.
+        """
+        #bad keys
+        self.assertEqual(make_xml_command(SET_DYNAMIC_VOL, "On"), None)
+        self.assertEqual(make_xml_command(SET_DIALOG_LEVEL, "13dB"), None)
+        #int instead of string
+        self.assertEqual(make_xml_command(SET_DYNAMIC_VOL, 0),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetAudyssey</name><list>\
+<param name="dynamicvol">0</param></list></cmd></tx>')
+        #value out of bounds too low
+        self.assertEqual(make_xml_command(SET_LFE, -11),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetSurroundParameter</name><list>\
+<param name="lfe">-10</param></list></cmd></tx>')
+        #value out of bounds too high
+        self.assertEqual(make_xml_command(SET_LFE, 1),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetSurroundParameter</name><list>\
+<param name="lfe">0</param></list></cmd></tx>')
+
+#------------------------------------------------------------------------------
+#   CLASS ATTRIBUTES MISSING
+
+    def test_missing_values(self):
+        """
+        Test handling missing values field.
+        """
+        self.assertEqual(make_xml_command(SET_LFE, -5),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetSurroundParameter</name><list>\
+<param name="lfe">-5</param></list></cmd></tx>')
+        self.assertEqual(make_xml_command(SET_LFE, "-5"),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="3"><name>SetSurroundParameter</name><list>\
+<param name="lfe">-5</param></list></cmd></tx>')
+
+#------------------------------------------------------------------------------
+#   CMD_ID=1 SYNTAX
+
+    def test_cmd_id_1_commands(self):
+        """
+        Test the slightly different syntax when cmd_id = 1.
+        """
+        self.assertEqual(make_xml_command(SET_CENTER_LEVEL, 30),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="1">SetChLevel</cmd><name>C</name><value>30</value></tx>')
+
+        self.assertEqual(make_xml_command(SET_DIALOG_LEVEL, "-11.5dB"),
+'<?xml version=\\\'1.0\\\' encoding=\\\'utf8\\\'?>\\n\
+<tx><cmd id="1">SetDialogLevel</cmd><value>1</value></tx>')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Here is what I have come up with for formatting commands gleaned from the XML data dump.  I have included one example command.  Here we use XmlCommand3 class because this is a command with the cmd id="3" (AppCommand0300.xml endpoint).  We enter first a friendly name, then the command name according to data dump, then a tuple representing the min and max values acceptable, then the param name as required by the API, then optionally enter a list which is going to allow the dev to later issue a string command, see below.

```
SET_DYNAMIC_VOL = XmlCommand3(
    "Dynamic Volume", "SetAudyssey",
    (0, 3), param="dynamicvol",
    values=[
        "Off",
        "Light",
        "Medium",
        "Heavy"]
)
```

In the main file you can see that we can now call this method: 
`denonavrobject.set_dynamic_range("Light")`
which would send the "1" command corresponding to its place on the list during object construction.  Error handling allows dev to send 1 or "1" as well for the same result.