### PR TITLE
Fix bug preventing All Zone Stereo from being disabled automatically

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1463,7 +1463,7 @@ class DenonAVR:
                 return True
             else:
                 return False
-        if self._sound_mode_raw == ALL_ZONE_STEREO:
+        if self._sound_mode_raw.upper() == ALL_ZONE_STEREO:
             if not self._set_all_zone_stereo(False):
                 return False
         # For selection of sound mode other names then at receiving sound modes


### PR DESCRIPTION
Likely related to issue #78. My receiver reports `self._sound_mode_raw` as `All Zone Stereo`, however your `if` in `set_sound_mode:1466` expects it to be uppercase - `ALL ZONE STEREO`. This change simply converts it to uppercase within the `if` statement, allowing All Zone Stereo to be disabled when necessary. I'm guessing that some receivers report it all caps, but mine (X1500H) uses title case.

It may be better to instead set  `self._sound_mode_raw` to uppercase automatically, rather than only in the `if`, however I didn't want to mess with too much.