### PR TITLE
alternative fix for #107

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1465,7 +1465,7 @@ class DenonAVR:
                 return True
             else:
                 return False
-        if self._sound_mode_raw.upper() == ALL_ZONE_STEREO:
+        if self.sound_mode == ALL_ZONE_STEREO:
             if not self._set_all_zone_stereo(False):
                 return False
         # For selection of sound mode other names then at receiving sound modes

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -68,7 +68,7 @@ SOUND_MODE_MAPPING = OrderedDict(
                        'DTS VIRTUAL:X', 'DTS-HD + NEURAL:X']),
      ('MCH STEREO', ['MULTI CH STEREO', 'MULTI_CH_STEREO', 'MCH STEREO']),
      ('STEREO', ['STEREO']),
-     (ALL_ZONE_STEREO, [ALL_ZONE_STEREO])])
+     (ALL_ZONE_STEREO, ['ALL ZONE STEREO'])])
 
 PLAYING_SOURCES = ("Online Music", "Media Server", "iPod/USB", "Bluetooth",
                    "Internet Radio", "Favorites", "SpotifyConnect", "Flickr",


### PR DESCRIPTION
I think using self.sound_mode is better than self._sound_mode_raw.upper(), because the whole point of self.sound_mode is that it is matched to a single value rather than the diffrent raw_sound_modes reported by the receiver (accross diffrent models).

Note that I have not tested this, because my receiver does not support ALL_ZONE_STEREO.