### PR TITLE
Modified DEVICEINFO_AVR_X_PATTERN to match AVC-X models

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -19,7 +19,7 @@ import requests
 _LOGGER = logging.getLogger("DenonAVR")
 
 DEVICEINFO_AVR_X_PATTERN = re.compile(
-    r"(.*AVR-(X|S).*|.*SR500[6-9]|.*SR60(07|08|09|10|11|12|13)|."
+    r"(.*AV(C|R)-(X|S).*|.*SR500[6-9]|.*SR60(07|08|09|10|11|12|13)|."
     r"*SR70(07|08|09|10|11|12|13)|.*NR16(04|05|06|07|08|09))")
 DEVICEINFO_COMMAPI_PATTERN = re.compile(r"(0210|0300)")
 


### PR DESCRIPTION
Fix to make the library work with my AVC-X8500H.