### PR TITLE
DEVICEINFO_COMMAPI_PATTERN pattern update

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -22,7 +22,7 @@ DEVICEINFO_AVR_X_PATTERN = re.compile(
     r"(.*AV(C|R)-(X|S).*|.*SR500[6-9]|.*SR60(07|08|09|10|11|12|13)|."
     r"*SR70(07|08|09|10|11|12|13)|.*NR1604|.*NR1710)")
 
-DEVICEINFO_COMMAPI_PATTERN = re.compile(r"(0210|0300)")
+DEVICEINFO_COMMAPI_PATTERN = re.compile(r"(0210|0300|0301)")
 
 ReceiverType = namedtuple('ReceiverType', ["type", "port"])
 AVR = ReceiverType(type="avr", port=80)


### PR DESCRIPTION
Update DEVICEINFO_COMMAPI_PATTERN to match latest firmware update for NR1609 and probably other AV receivers.