### PR TITLE
Adding support for Python 2.7.  Specific changes:

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -659,11 +659,11 @@ class DenonAVR(object):
             self._input_func_list_rev.clear()
             if "clear" in dir(self._netaudio_func_list):
                 self._netaudio_func_list.clear()
-            else: # Python 2 support
+            else:  # Python 2 support
                 del self._netaudio_func_list[:]
             if "clear" in dir(self._playing_func_list):
                 self._playing_func_list.clear()
-            else: # Python 2 support
+            else:  # Python 2 support
                 del self._playing_func_list[:]
 
             for item in receiver_sources.items():
@@ -704,11 +704,11 @@ class DenonAVR(object):
             self._input_func_list_rev.clear()
             if "clear" in dir(self._netaudio_func_list):
                 self._netaudio_func_list.clear()
-            else: # Python 2 support
+            else:  # Python 2 support
                 del self._netaudio_func_list[:]
             if "clear" in dir(self._playing_func_list):
                 self._playing_func_list.clear()
-            else: # Python 2 support
+            else:  # Python 2 support
                 del self._playing_func_list[:]
             for item in receiver_sources.items():
                 self._input_func_list[item[1]] = item[0]
@@ -1765,7 +1765,7 @@ class DenonAVRZones(DenonAVR):
             super().__init__(self._parent_avr.host, name=name,
                              show_all_inputs=self._parent_avr.show_all_inputs,
                              timeout=self._parent_avr.timeout)
-        else: # Python 2 support
+        else:  # Python 2 support
             super(DenonAVRZones, self).__init__(self._parent_avr.host, name=name,
                              show_all_inputs=self._parent_avr.show_all_inputs,
                              timeout=self._parent_avr.timeout)

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -7,6 +7,7 @@ This module implements the interface to Denon AVR receivers.
 :license: MIT, see LICENSE for more details.
 """
 
+import sys
 from collections import (namedtuple, OrderedDict)
 from io import BytesIO
 import logging
@@ -235,7 +236,7 @@ ZONE3 = {"Zone3": None}
 ZONE2_ZONE3 = {"Zone2": None, "Zone3": None}
 
 
-class DenonAVR:
+class DenonAVR(object):
     """Representing a Denon AVR Device."""
 
     def __init__(self, host, name=None, show_all_inputs=False, timeout=2.0,
@@ -656,8 +657,14 @@ class DenonAVR:
             # Clear and rebuild the sources lists
             self._input_func_list.clear()
             self._input_func_list_rev.clear()
-            self._netaudio_func_list.clear()
-            self._playing_func_list.clear()
+            if "clear" in dir(self._netaudio_func_list):
+                self._netaudio_func_list.clear()
+            else: # Python 2 support
+                del self._netaudio_func_list[:]
+            if "clear" in dir(self._playing_func_list):
+                self._playing_func_list.clear()
+            else: # Python 2 support
+                del self._playing_func_list[:]
 
             for item in receiver_sources.items():
                 # Mapping of item[0] because some func names are inconsistant
@@ -695,8 +702,14 @@ class DenonAVR:
             # Clear and rebuild the sources lists
             self._input_func_list.clear()
             self._input_func_list_rev.clear()
-            self._netaudio_func_list.clear()
-            self._playing_func_list.clear()
+            if "clear" in dir(self._netaudio_func_list):
+                self._netaudio_func_list.clear()
+            else: # Python 2 support
+                del self._netaudio_func_list[:]
+            if "clear" in dir(self._playing_func_list):
+                self._playing_func_list.clear()
+            else: # Python 2 support
+                del self._playing_func_list[:]
             for item in receiver_sources.items():
                 self._input_func_list[item[1]] = item[0]
                 self._input_func_list_rev[item[0]] = item[1]
@@ -1748,9 +1761,16 @@ class DenonAVRZones(DenonAVR):
         """
         self._parent_avr = parent_avr
         self._zone = zone
-        super().__init__(self._parent_avr.host, name=name,
-                         show_all_inputs=self._parent_avr.show_all_inputs,
-                         timeout=self._parent_avr.timeout)
+        if (sys.version_info > (3, 0)):
+            super().__init__(self._parent_avr.host, name=name,
+                             show_all_inputs=self._parent_avr.show_all_inputs,
+                             timeout=self._parent_avr.timeout)
+        else: # Python 2 support
+            super(DenonAVRZones, self).__init__(self._parent_avr.host, name=name,
+                             show_all_inputs=self._parent_avr.show_all_inputs,
+                             timeout=self._parent_avr.timeout)
+        self._testing_receiver = None
+
 
     @property
     def sound_mode(self):

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1762,13 +1762,17 @@ class DenonAVRZones(DenonAVR):
         self._parent_avr = parent_avr
         self._zone = zone
         if (sys.version_info > (3, 0)):
-            super().__init__(self._parent_avr.host, name=name,
-                             show_all_inputs=self._parent_avr.show_all_inputs,
-                             timeout=self._parent_avr.timeout)
+            super().__init__(
+                self._parent_avr.host,
+                name=name,
+                show_all_inputs=self._parent_avr.show_all_inputs,
+                timeout=self._parent_avr.timeout)
         else:  # Python 2 support
-            super(DenonAVRZones, self).__init__(self._parent_avr.host, name=name,
-                             show_all_inputs=self._parent_avr.show_all_inputs,
-                             timeout=self._parent_avr.timeout)
+            super(DenonAVRZones, self).__init__(
+                self._parent_avr.host,
+                name=name,
+                show_all_inputs=self._parent_avr.show_all_inputs,
+                timeout=self._parent_avr.timeout)
         self._testing_receiver = None
 
 

--- a/denonavr/ssdp.py
+++ b/denonavr/ssdp.py
@@ -11,7 +11,10 @@ This module implements a discovery function for Denon AVR receivers.
 import logging
 import socket
 import xml.etree.ElementTree as ET
-from urllib.parse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 import requests
 
 _LOGGER = logging.getLogger('DenonSSDP')

--- a/tests/test_denonavr.py
+++ b/tests/test_denonavr.py
@@ -7,11 +7,23 @@ This module covers some basic automated tests of Denon AVR receivers.
 :license: MIT, see LICENSE for more details.
 """
 
-from urllib.parse import urlparse
+import sys
+from io import open
+
+try:
+    from urllib.parse import urlparse
+except ImportError: # Python 2 support
+    from urlparse import urlparse
 import testtools
 import requests
 import requests_mock
 import denonavr
+
+# Python 2 support: Define FileNotFoundError
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
 
 FAKE_IP = "10.0.0.0"
 
@@ -52,14 +64,20 @@ class TestMainFunctions(testtools.TestCase):
 
     def __init__(self, *args, **kwargs):
         """Initialize."""
-        super().__init__(*args, **kwargs)
+        if (sys.version_info > (3, 0)):
+            super().__init__(*args, **kwargs)
+        else: # Python 2 support
+            super(TestMainFunctions, self).__init__(*args, **kwargs)
         self._testing_receiver = None
 
     @requests_mock.mock()
     # pylint: disable=arguments-differ
     def setUp(self, mocker):
         """Initialize test functions, using the first receiver from list."""
-        super().setUp()
+        if (sys.version_info > (3, 0)):
+            super().setUp()
+        else: # Python 2 support
+            super(TestMainFunctions, self).setUp()
         self.denon = None
 
     def custom_matcher(self, request):

--- a/tests/test_denonavr.py
+++ b/tests/test_denonavr.py
@@ -12,7 +12,7 @@ from io import open
 
 try:
     from urllib.parse import urlparse
-except ImportError: # Python 2 support
+except ImportError:  # Python 2 support
     from urlparse import urlparse
 import testtools
 import requests
@@ -66,7 +66,7 @@ class TestMainFunctions(testtools.TestCase):
         """Initialize."""
         if (sys.version_info > (3, 0)):
             super().__init__(*args, **kwargs)
-        else: # Python 2 support
+        else:  # Python 2 support
             super(TestMainFunctions, self).__init__(*args, **kwargs)
         self._testing_receiver = None
 
@@ -76,7 +76,7 @@ class TestMainFunctions(testtools.TestCase):
         """Initialize test functions, using the first receiver from list."""
         if (sys.version_info > (3, 0)):
             super().setUp()
-        else: # Python 2 support
+        else:  # Python 2 support
             super(TestMainFunctions, self).setUp()
         self.denon = None
 


### PR DESCRIPTION
 - Explicitly inheirting DenonAVR from object (needed to support super() call)
 - Manual list clears (since clear() does not exist for lists in 2.7)
 - Python 2.7 super() call fix
 - Importing from urlparse instead of urllib.parse
 - Defining FileNotFoundError exception (since this doesn't exist in 2.7)
 - using io.open() because vanilla open() does not support encoding keyword