### PR TITLE
fix FutureWarning

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1028,7 +1028,7 @@ class DenonAVR:
             receiver_sources = {}
             # Source determination from XML
             favorites = root.find(".//FavoriteStation")
-            if len(favorites):
+            if favorites is not None:
                 for child in favorites:
                     if not child.tag.startswith("Favorite"):
                         continue

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1028,7 +1028,7 @@ class DenonAVR:
             receiver_sources = {}
             # Source determination from XML
             favorites = root.find(".//FavoriteStation")
-            if favorites:
+            if len(favorites):
                 for child in favorites:
                     if not child.tag.startswith("Favorite"):
                         continue


### PR DESCRIPTION
When looking at the log of HomeAssistant I came occros this:
`/srv/homeassistant/lib/python3.7/site-packages/denonavr/denonavr.py:1031: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.`
This fixes that