### PR TITLE
reduce log level Receiver name missing

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -828,14 +828,14 @@ class DenonAVR:
                 pass
             except (ValueError, requests.exceptions.RequestException):
                 _LOGGER.info("Receiver name could not be determined. "
-                                "Using standard name: Denon AVR.")
+                             "Using standard name: Denon AVR.")
                 self._name = "Denon AVR"
             else:
                 # Get the tags from this XML
                 name_tag = self._get_status_from_xml_tags(root, name_tag)
                 if name_tag:
                     _LOGGER.info("Receiver name could not be determined. "
-                                    "Using standard name: Denon AVR.")
+                                 "Using standard name: Denon AVR.")
                     self._name = "Denon AVR"
 
     def _get_receiver_name_avr_2016(self):

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1789,7 +1789,7 @@ class DenonAVR:
                 return False
 
     def power_on(self):
-        """Turn off receiver via HTTP get command."""
+        """Turn on receiver via HTTP get command."""
         try:
             if self.send_get_command(self._urls.command_power_on):
                 self._power = POWER_ON

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -827,14 +827,14 @@ class DenonAVR:
             except requests.exceptions.ConnectTimeout:
                 pass
             except (ValueError, requests.exceptions.RequestException):
-                _LOGGER.warning("Receiver name could not be determined. "
+                _LOGGER.info("Receiver name could not be determined. "
                                 "Using standard name: Denon AVR.")
                 self._name = "Denon AVR"
             else:
                 # Get the tags from this XML
                 name_tag = self._get_status_from_xml_tags(root, name_tag)
                 if name_tag:
-                    _LOGGER.warning("Receiver name could not be determined. "
+                    _LOGGER.info("Receiver name could not be determined. "
                                     "Using standard name: Denon AVR.")
                     self._name = "Denon AVR"
 

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -87,7 +87,8 @@ SOUND_MODE_MAPPING = OrderedDict(
                        'DTS + NEURAL:X', 'MULTI CH IN', 'DTS-HD MSTR',
                        'DTS VIRTUAL:X', 'DTS-HD + NEURAL:X', 'DTS-HD',
                        'DTS + VIRTUAL:X']),
-     ('MCH STEREO', ['MULTI CH STEREO', 'MULTI_CH_STEREO', 'MCH STEREO']),
+     ('MCH STEREO', ['MULTI CH STEREO', 'MULTI_CH_STEREO', 'MCH STEREO',
+                     'MULTI CH IN 7.1']),
      ('STEREO', ['STEREO']),
      (ALL_ZONE_STEREO, ['ALL ZONE STEREO'])])
 


### PR DESCRIPTION
see the complaint in this issue about the warning that keeps showing up in the log while the warning is not that important: https://github.com/home-assistant/core/issues/37484

This will also close: https://github.com/scarface-4711/denonavr/issues/149