### PR TITLE
Generalize XML commands

### DIFF
--- a/denonavr/audyssey.py
+++ b/denonavr/audyssey.py
@@ -28,6 +28,13 @@ class AppCommand0300:
         :type receiver: DenonAVR
         """
         self.receiver = receiver
+        self.param_labels = None
+        self._params = None
+        self._get_cmd_name = None
+        self._set_cmd_name = None
+
+    def _init_param_labels(self):
+        """Create the map self.param_labels."""
         if self._params:
             self.param_labels = {
                 param: {value: key for key, value in inner.items()}
@@ -35,7 +42,7 @@ class AppCommand0300:
             }
         else:
             _LOGGER.warning("Class AppCommand0300 initialized without params.")
-
+    
     def send_command(self, xml_tree):
         """Send commands."""
         body = BytesIO()
@@ -146,6 +153,7 @@ class Audyssey(AppCommand0300):
         :type receiver: DenonAVR
         """
 
+        super().__init__(receiver)
         self._set_cmd_name = "SetAudyssey"
         self._get_cmd_name = "GetAudyssey"
         self._params = {
@@ -172,11 +180,11 @@ class Audyssey(AppCommand0300):
                 "3": "Reference",
             },
         }
+        self._init_param_labels()
         self.dynamiceq = None
         self.multeq = None
         self.reflevoffset = None
         self.dynamicvol = None
-        super().__init__(receiver)
 
     def dynamiceq_off(self):
         """Turn DynamicEQ off."""
@@ -225,7 +233,7 @@ class SurroundParameter(AppCommand0300):
         :param receiver: DenonAVR Receiver
         :type receiver: DenonAVR
         """
-
+        super().__init__(receiver)
         self._set_cmd_name = "SetSurroundParameter"
         self._get_cmd_name = "GetSurroundParameter"
         self._params = {
@@ -237,9 +245,9 @@ class SurroundParameter(AppCommand0300):
             },
             "lfe": {str(gain): f"{str(gain)}dB" for gain in range(0, -11, -1)},
         }
+        self._init_param_labels()
         self.dyncomp = None
         self.lfe = None
-        super().__init__(receiver)
 
     def set_dyncomp(self, setting):
         """Set Dolby Dynamic Compression mode."""

--- a/denonavr/audyssey.py
+++ b/denonavr/audyssey.py
@@ -42,7 +42,15 @@ class AppCommand0300:
             }
         else:
             _LOGGER.warning("Class AppCommand0300 initialized without params.")
-    
+
+    def list_parameter_options(self, param):
+        """List the valid options for param."""
+        labels = self.param_labels.get(param)
+        if labels is None:
+            _LOGGER.warning("Parameter: %s not found.", param)
+            return []
+        return list(labels.keys())
+
     def send_command(self, xml_tree):
         """Send commands."""
         body = BytesIO()

--- a/denonavr/audyssey.py
+++ b/denonavr/audyssey.py
@@ -172,51 +172,46 @@ class Audyssey(AppCommand0300):
                 "3": "Reference",
             },
         }
+        self.dynamiceq = None
+        self.multeq = None
+        self.reflevoffset = None
+        self.dynamicvol = None
         super().__init__(receiver)
 
     def dynamiceq_off(self):
         """Turn DynamicEQ off."""
-        if self._set(parameter="dynamiceq", value=0) is True:
+        success = self._set(parameter="dynamiceq", value=0)
+        if success:
             self.dynamiceq = False
 
     def dynamiceq_on(self):
         """Turn DynamicEQ on."""
-        if self._set(parameter="dynamiceq", value=1) is True:
+        success = self._set(parameter="dynamiceq", value=1)
+        if success:
             self.dynamiceq = True
 
     def set_multieq(self, setting):
         """Set MultiEQ mode."""
-        if (
-            self._set(
-                parameter="multeq", value=self.param_labels["multeq"].get(setting)
-            )
-            is True
-        ):
+        value = self.param_labels["multeq"].get(setting)
+        success = self._set(parameter="multeq", value=value)
+        if success:
             self.multeq = setting
 
     def set_reflevoffset(self, setting):
         """Set Reference Level Offset."""
         # Reference level offset can only be used with DynamicEQ
-        # TODO: Let's take advantage of the "control" attr given by API
-        if self.dynamiceq is True:
-            if (
-                self._set(
-                    parameter="reflevoffset",
-                    value=self.param_labels["reflevoffset"].get(setting),
-                )
-                is True
-            ):
-                self.reflevoffset = setting
+        if self.dynamiceq is False:
+            return
+        value = self.param_labels["reflevoffset"].get(setting)
+        success = self._set(parameter="reflevoffset", value=value)
+        if success:
+            self.reflevoffset = setting
 
     def set_dynamicvol(self, setting):
         """Set Dynamic Volume."""
-        if (
-            self._set(
-                parameter="dynamicvol",
-                value=self.param_labels["dynamicvol"].get(setting),
-            )
-            is True
-        ):
+        value = self.param_labels["dynamicvol"].get(setting)
+        success = self._set(parameter="dynamicvol", value=value)
+        if success:
             self.dynamicvol = setting
 
 
@@ -242,25 +237,20 @@ class SurroundParameter(AppCommand0300):
             },
             "lfe": {str(gain): f"{str(gain)}dB" for gain in range(0, -11, -1)},
         }
+        self.dyncomp = None
+        self.lfe = None
         super().__init__(receiver)
 
     def set_dyncomp(self, setting):
         """Set Dolby Dynamic Compression mode."""
-        if (
-            self._set(
-                parameter="dyncomp", value=self.param_labels["dyncomp"].get(setting)
-            )
-            is True
-        ):
+        value = self.param_labels["dyncomp"].get(setting)
+        success = self._set(parameter="dyncomp", value=value)
+        if success:
             self.dyncomp = setting
 
     def set_lfe(self, setting):
         """Set Dynamic Volume."""
-        if (
-            self._set(
-                parameter="lfe",
-                value=self.param_labels["lfe"].get(setting),
-            )
-            is True
-        ):
+        value = self.param_labels["lfe"].get(setting)
+        success = self._set(parameter="lfe", value=value)
+        if success:
             self.lfe = setting

--- a/denonavr/audyssey.py
+++ b/denonavr/audyssey.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-This module implements the Audyssey settings of Denon AVR receivers.
+This module implements the XML Commands of Denon AVR receivers.
 
 :copyright: (c) 2016 by Oliver Goetz.
 :license: MIT, see LICENSE for more details.
@@ -10,46 +10,31 @@ This module implements the Audyssey settings of Denon AVR receivers.
 import logging
 from io import BytesIO
 import xml.etree.ElementTree as ET
-from requests.exceptions import RequestException
+from requests.exceptions import ConnectTimeout, RequestException
 
-_LOGGER = logging.getLogger("Audyssey")
-
-MULTI_EQ_MAP = {"0": "Off", "1": "Flat", "2": "L/R Bypass", "3": "Reference"}
-MULTI_EQ_MAP_LABELS = dict((value, key) for key, value in MULTI_EQ_MAP.items())
-
-REF_LVL_OFFSET_MAP = {"0": "0dB", "1": "+5dB", "2": "+10dB", "3": "+15dB"}
-REF_LVL_OFFSET_MAP_LABELS = dict(
-    (value, key) for key, value in REF_LVL_OFFSET_MAP.items()
-)
-
-DYNAMIC_VOLUME_MAP = {"0": "Off", "1": "Light", "2": "Medium", "3": "Heavy"}
-DYNAMIC_VOLUME_MAP_LABELS = dict(
-    (value, key) for key, value in DYNAMIC_VOLUME_MAP.items()
-)
+_LOGGER = logging.getLogger("AppCommand0300")
 
 COMMAND_ENDPOINT = "/goform/AppCommand0300.xml"
 
 
-class Audyssey:
-    """Audyssey Settings."""
+class AppCommand0300:
+    """AppCommand0300 Base Class."""
 
     def __init__(self, receiver):
         """
-        Initialize Audyssey Settings of DenonAVR.
+        Initialize Command Settings of DenonAVR.
 
         :param receiver: DenonAVR Receiver
         :type receiver: DenonAVR
         """
         self.receiver = receiver
-
-        self.dynamiceq = None
-        self.dynamiceq_control = None
-        self.reflevoffset = None
-        self.reflevoffset_control = None
-        self.dynamicvol = None
-        self.dynamicvol_control = None
-        self.multeq = None
-        self.multeq_control = None
+        if self._params:
+            self.param_labels = {
+                param: {value: key for key, value in inner.items()}
+                for param, inner in self._params.items()
+            }
+        else:
+            _LOGGER.warning("Class AppCommand0300 initialized without params.")
 
     def send_command(self, xml_tree):
         """Send commands."""
@@ -57,18 +42,20 @@ class Audyssey:
         xml_tree.write(body, encoding="utf-8", xml_declaration=True)
         try:
             result = self.receiver.send_post_command(
-                command=COMMAND_ENDPOINT, body=body.getvalue())
-        except RequestException:
+                command=COMMAND_ENDPOINT, body=body.getvalue()
+            )
+        except (ConnectTimeout, RequestException):
             _LOGGER.error(
                 "No connection to %s end point on host %s",
-                COMMAND_ENDPOINT, self.receiver.host)
+                COMMAND_ENDPOINT,
+                self.receiver.host,
+            )
             return
-        finally:
-            # Buffered XML not needed anymore: close
-            body.close()
 
         if result is None:
             return
+
+        _LOGGER.debug("Command:\n%s\nResponse:\n%s", body.getvalue(), result)
 
         try:
             # Return XML ElementTree
@@ -77,17 +64,18 @@ class Audyssey:
         except (ET.ParseError, TypeError):
             _LOGGER.error(
                 "End point %s on host %s returned malformed XML.",
-                COMMAND_ENDPOINT, self.receiver.host)
+                COMMAND_ENDPOINT,
+                self.receiver.host,
+            )
             return
 
     def update(self):
         """Update settings."""
         root = ET.Element("tx")
         cmd = ET.SubElement(root, "cmd", id="3")
-        ET.SubElement(cmd, "name").text = "GetAudyssey"
-        valid_params = ["dynamiceq", "reflevoffset", "dynamicvol", "multeq"]
+        ET.SubElement(cmd, "name").text = self._get_cmd_name
         param_list = ET.SubElement(cmd, "list")
-        for param in valid_params:
+        for param in self._params.keys():
             ET.SubElement(param_list, "param", name=param)
         tree = ET.ElementTree(root)
 
@@ -101,29 +89,38 @@ class Audyssey:
             return False
 
         for param in audyssey_params:
-            if param.get("name") not in valid_params:
+            name = param.get("name")
+            if not name:
                 continue
-            if param.get("name") == "multeq":
-                self.multeq = MULTI_EQ_MAP.get(param.text)
-            elif param.get("name") == "dynamiceq":
-                self.dynamiceq = bool(int(param.text))
-            elif param.get("name") == "reflevoffset":
-                # Reference level offset can only be used with DynamicEQ
-                if self.dynamiceq is False:
-                    self.reflevoffset = False
-                else:
-                    self.reflevoffset = REF_LVL_OFFSET_MAP.get(param.text)
-            elif param.get("name") == "dynamicvol":
-                self.dynamicvol = DYNAMIC_VOLUME_MAP.get(param.text)
-            setattr(
-                self, "{name}_control".format(name=param.get("name")),
-                bool(int(param.get("control"))))
+
+            map_key = self._params.get(name)
+            if not map_key:
+                _LOGGER.warning("Unmapped name: %s", name)
+                continue
+
+            param_text = param.text
+            if not param_text:
+                _LOGGER.debug(
+                    "Parameter: %s has no text attribute (state). param control=%s",
+                    param,
+                    param.get("control"),
+                )
+                continue
+
+            param_state = map_key.get(param.text)
+            if not param_state:
+                _LOGGER.warning("State: %s not found in map for %s", param_text, name)
+                continue
+
+            setattr(self, name, param_state)
+            setattr(self, f"{name}_control", bool(int(param.get("control"))))
+
         return True
 
-    def _set_audyssey(self, parameter, value):
+    def _set(self, parameter, value):
         root = ET.Element("tx")
         cmd = ET.SubElement(root, "cmd", id="3")
-        ET.SubElement(cmd, "name").text = "SetAudyssey"
+        ET.SubElement(cmd, "name").text = self._set_cmd_name
         param_list = ET.SubElement(cmd, "list")
         ET.SubElement(param_list, "param", name=parameter).text = str(value)
         tree = ET.ElementTree(root)
@@ -137,37 +134,133 @@ class Audyssey:
 
         return False
 
+
+class Audyssey(AppCommand0300):
+    """Audyssey Commands."""
+
+    def __init__(self, receiver):
+        """
+        Initialize Audyssey Settings of DenonAVR.
+
+        :param receiver: DenonAVR Receiver
+        :type receiver: DenonAVR
+        """
+
+        self._set_cmd_name = "SetAudyssey"
+        self._get_cmd_name = "GetAudyssey"
+        self._params = {
+            "dynamiceq": {
+                "0": "Off",
+                "1": "On",
+            },
+            "reflevoffset": {
+                "0": "0dB",
+                "1": "+5dB",
+                "2": "+10dB",
+                "3": "+15dB",
+            },
+            "dynamicvol": {
+                "0": "Off",
+                "1": "Light",
+                "2": "Medium",
+                "3": "Heavy",
+            },
+            "multeq": {
+                "0": "Off",
+                "1": "Flat",
+                "2": "L/R Bypass",
+                "3": "Reference",
+            },
+        }
+        super().__init__(receiver)
+
     def dynamiceq_off(self):
         """Turn DynamicEQ off."""
-        if self._set_audyssey(parameter="dynamiceq", value=0) is True:
+        if self._set(parameter="dynamiceq", value=0) is True:
             self.dynamiceq = False
 
     def dynamiceq_on(self):
         """Turn DynamicEQ on."""
-        if self._set_audyssey(parameter="dynamiceq", value=1) is True:
+        if self._set(parameter="dynamiceq", value=1) is True:
             self.dynamiceq = True
 
-    def set_mutlieq(self, setting):
+    def set_multieq(self, setting):
         """Set MultiEQ mode."""
-        if self._set_audyssey(
-                parameter="multeq", value=MULTI_EQ_MAP_LABELS.get(setting)
-                ) is True:
+        if (
+            self._set(
+                parameter="multeq", value=self.param_labels["multeq"].get(setting)
+            )
+            is True
+        ):
             self.multeq = setting
 
     def set_reflevoffset(self, setting):
         """Set Reference Level Offset."""
         # Reference level offset can only be used with DynamicEQ
+        # TODO: Let's take advantage of the "control" attr given by API
         if self.dynamiceq is True:
-            if self._set_audyssey(
+            if (
+                self._set(
                     parameter="reflevoffset",
-                    value=REF_LVL_OFFSET_MAP_LABELS.get(setting)
-                        ) is True:
+                    value=self.param_labels["reflevoffset"].get(setting),
+                )
+                is True
+            ):
                 self.reflevoffset = setting
 
     def set_dynamicvol(self, setting):
         """Set Dynamic Volume."""
-        if self._set_audyssey(
+        if (
+            self._set(
                 parameter="dynamicvol",
-                value=DYNAMIC_VOLUME_MAP_LABELS.get(setting)
-                ) is True:
+                value=self.param_labels["dynamicvol"].get(setting),
+            )
+            is True
+        ):
             self.dynamicvol = setting
+
+
+class SurroundParameter(AppCommand0300):
+    """SurroundParameter Commands."""
+
+    def __init__(self, receiver):
+        """
+        Initialize SurroundParameter Settings of DenonAVR.
+
+        :param receiver: DenonAVR Receiver
+        :type receiver: DenonAVR
+        """
+
+        self._set_cmd_name = "SetSurroundParameter"
+        self._get_cmd_name = "GetSurroundParameter"
+        self._params = {
+            "dyncomp": {
+                "0": "Off",
+                "1": "Low",
+                "2": "Medium",
+                "3": "High",
+            },
+            "lfe": {str(gain): f"{str(gain)}dB" for gain in range(0, -11, -1)},
+        }
+        super().__init__(receiver)
+
+    def set_dyncomp(self, setting):
+        """Set Dolby Dynamic Compression mode."""
+        if (
+            self._set(
+                parameter="dyncomp", value=self.param_labels["dyncomp"].get(setting)
+            )
+            is True
+        ):
+            self.dyncomp = setting
+
+    def set_lfe(self, setting):
+        """Set Dynamic Volume."""
+        if (
+            self._set(
+                parameter="lfe",
+                value=self.param_labels["lfe"].get(setting),
+            )
+            is True
+        ):
+            self.lfe = setting

--- a/denonavr/commands.py
+++ b/denonavr/commands.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the XML Commands of Denon AVR receivers.
+
+:copyright: (c) 2016 by Oliver Goetz.
+:license: MIT, see LICENSE for more details.
+"""
+
+COMMAND_ENDPOINT = "/goform/AppCommand0300.xml"
+
+AUDYSSEY_SET_CMD = "SetAudyssey"
+AUDYSSEY_GET_CMD = "GetAudyssey"
+AUDYSSEY_PARAMS = {
+    "dynamiceq": {
+        "0": "Off",
+        "1": "On",
+    },
+    "reflevoffset": {
+        "0": "0dB",
+        "1": "+5dB",
+        "2": "+10dB",
+        "3": "+15dB",
+    },
+    "dynamicvol": {
+        "0": "Off",
+        "1": "Light",
+        "2": "Medium",
+        "3": "Heavy",
+    },
+    "multeq": {
+        "0": "Off",
+        "1": "Flat",
+        "2": "L/R Bypass",
+        "3": "Reference",
+    },
+}
+
+SURROUND_PARAMETER_SET_CMD = "SetSurroundParameter"
+SURROUND_PARAMETER_GET_CMD = "GetSurroundParameter"
+SURROUND_PARAMETER_PARAMS = {
+    "dyncomp": {
+        "0": "Off",
+        "1": "Low",
+        "2": "Medium",
+        "3": "High",
+    },
+    "lfe": {str(gain): f"{str(gain)}dB" for gain in range(0, -11, -1)},
+}

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1674,7 +1674,7 @@ class DenonAVR:
     @property
     def reference_level_offset_setting_list(self):
         """Return a list of available reference level offset settings."""
-        return list(self._audyssey.param_labels.get("reflevoffset").keys())
+        return self._audyssey.list_parameter_options("reflevoffset")
 
     @property
     def dynamic_volume(self):
@@ -1684,7 +1684,7 @@ class DenonAVR:
     @property
     def dynamic_volume_setting_list(self):
         """Return a list of available Dynamic Volume settings."""
-        return list(self._audyssey.param_labels.get("dynamicvol").keys())
+        return self._audyssey.list_parameter_options("dynamicvol")
 
     @property
     def multi_eq(self):
@@ -1694,7 +1694,7 @@ class DenonAVR:
     @property
     def multi_eq_setting_list(self):
         """Return a list of available MultiEQ settings."""
-        return list(self._audyssey.param_labels.get("multeq").keys())
+        return self._audyssey.list_parameter_options("multeq")
     
     @property
     def dyncomp(self):
@@ -1704,7 +1704,7 @@ class DenonAVR:
     @property
     def dyncomp_setting_list(self):
         """Return a list of available Dynamic Compression settings."""
-        return list(self._surround_parameter.param_labels.get("dyncomp").keys())
+        return self._surround_parameter.list_parameter_options("dyncomp")
 
     @property
     def lfe(self):
@@ -1714,7 +1714,7 @@ class DenonAVR:
     @property
     def lfe_setting_list(self):
         """Return a list of available Dynamic Compression settings."""
-        return list(self._surround_parameter.param_labels.get("lfe").keys())
+        return self._surround_parameter.list_parameter_options("lfe")
 
     def dynamic_eq_off(self):
         """Turn DynamicEQ off."""

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1695,7 +1695,7 @@ class DenonAVR:
     def multi_eq_setting_list(self):
         """Return a list of available MultiEQ settings."""
         return self._audyssey.list_parameter_options("multeq")
-    
+
     @property
     def dyncomp(self):
         """Return value of Dolby Dynamic Compression."""
@@ -1745,7 +1745,7 @@ class DenonAVR:
     def multi_eq(self, setting):
         """Set MultiEQ."""
         self._audyssey.set_multieq(setting=setting)
-    
+
     @dyncomp.setter
     def dyncomp(self, setting):
         """Set Dolby Dynamic Compression."""

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -20,12 +20,7 @@ import requests
 
 from .ssdp import evaluate_scpd_xml
 
-from .audyssey import (
-    Audyssey,
-    REF_LVL_OFFSET_MAP_LABELS,
-    MULTI_EQ_MAP_LABELS,
-    DYNAMIC_VOLUME_MAP_LABELS,
-    )
+from .audyssey import Audyssey, SurroundParameter
 
 _LOGGER = logging.getLogger("DenonAVR")
 
@@ -339,6 +334,7 @@ class DenonAVR:
         self._treble_level = None
 
         self._audyssey = Audyssey(receiver=self)
+        self._surround_parameter = SurroundParameter(receiver=self)
 
         # Get initial setting of values
         self.update()
@@ -1678,7 +1674,7 @@ class DenonAVR:
     @property
     def reference_level_offset_setting_list(self):
         """Return a list of available reference level offset settings."""
-        return list(REF_LVL_OFFSET_MAP_LABELS.keys())
+        return list(self._audyssey.param_labels.get("reflevoffset").keys())
 
     @property
     def dynamic_volume(self):
@@ -1688,7 +1684,7 @@ class DenonAVR:
     @property
     def dynamic_volume_setting_list(self):
         """Return a list of available Dynamic Volume settings."""
-        return list(DYNAMIC_VOLUME_MAP_LABELS.keys())
+        return list(self._audyssey.param_labels.get("dynamicvol").keys())
 
     @property
     def multi_eq(self):
@@ -1698,7 +1694,27 @@ class DenonAVR:
     @property
     def multi_eq_setting_list(self):
         """Return a list of available MultiEQ settings."""
-        return list(MULTI_EQ_MAP_LABELS.keys())
+        return list(self._audyssey.param_labels.get("multeq").keys())
+    
+    @property
+    def dyncomp(self):
+        """Return value of Dolby Dynamic Compression."""
+        return self._surround_parameter.dyncomp
+
+    @property
+    def dyncomp_setting_list(self):
+        """Return a list of available Dynamic Compression settings."""
+        return list(self._surround_parameter.param_labels.get("dyncomp").keys())
+
+    @property
+    def lfe(self):
+        """Return value of Dolby Dynamic Compression."""
+        return self._surround_parameter.lfe
+
+    @property
+    def lfe_setting_list(self):
+        """Return a list of available Dynamic Compression settings."""
+        return list(self._surround_parameter.param_labels.get("lfe").keys())
 
     def dynamic_eq_off(self):
         """Turn DynamicEQ off."""
@@ -1728,7 +1744,17 @@ class DenonAVR:
     @multi_eq.setter
     def multi_eq(self, setting):
         """Set MultiEQ."""
-        self._audyssey.set_mutlieq(setting=setting)
+        self._audyssey.set_multieq(setting=setting)
+    
+    @dyncomp.setter
+    def dyncomp(self, setting):
+        """Set Dolby Dynamic Compression."""
+        self._surround_parameter.set_dyncomp(setting=setting)
+
+    @lfe.setter
+    def lfe(self, setting):
+        """Set LFE level."""
+        self._surround_parameter.set_lfe(setting=setting)
 
     @input_func.setter
     def input_func(self, input_func):


### PR DESCRIPTION
Here's a followup to @MarBra 's work on the Audyssey commands.  

New schema
For each new XML command class, three constants would be defined in commands.py eg:
```python3
AUDYSSEY_SET_CMD = "SetAudyssey"
AUDYSSEY_GET_CMD = "GetAudyssey"
AUDYSSEY_PARAMS = {
    "dynamiceq": {
        "0": "Off",
        "1": "On",
    },
    "reflevoffset": {
        "0": "0dB",
        "1": "+5dB",
        "2": "+10dB",
        "3": "+15dB",
    },
    "dynamicvol": {
        "0": "Off",
        "1": "Light",
        "2": "Medium",
        "3": "Heavy",
    },
    "multeq": {
        "0": "Off",
        "1": "Flat",
        "2": "L/R Bypass",
        "3": "Reference",
    },
}
```
To define the new command class the init looks like:
```python3
class Audyssey(AppCommand0300):
    """Audyssey Commands."""

    def __init__(self, receiver):
        """
        Initialize Audyssey Settings of DenonAVR.

        :param receiver: DenonAVR Receiver
        :type receiver: DenonAVR
        """

        super().__init__(receiver)
        self._init_commands(
            set_cmd=AUDYSSEY_SET_CMD, get_cmd=AUDYSSEY_GET_CMD, params=AUDYSSEY_PARAMS
        )
        self.dynamiceq = None
        self.multeq = None
        self.reflevoffset = None
        self.dynamicvol = None
```
Note that the attributes defined in AUDYSSEY_PARAMS are initialized here as None - this is their actual state as reported by the receiver and will be updated when the update method is called.

Next, methods would be filled in for each setting, eg:
```python3
def set_multieq(self, setting):
    """Set MultiEQ mode."""
    value = self._param_labels["multeq"].get(setting)
    success = self._set(parameter="multeq", value=value)
    if success:
        self.multeq = setting
```

Finally, the command class must be imported to denonavr.py and initialized:
```python3
from .audyssey import Audyssey, SurroundParameter

self._surround_parameter = SurroundParameter(receiver=self)
```

And expose getters, setters and "listers" to the public interface:
```python3
class DenonAVR:
...
    @property
    def multi_eq(self):
        """Return value of MultiEQ."""
        return self._audyssey.multeq
...
    @property
    def multi_eq_setting_list(self):
        """Return a list of available MultiEQ settings."""
        return self._audyssey.list_parameter_options("multeq")
...
    @multi_eq.setter
    def multi_eq(self, setting):
        """Set MultiEQ."""
        self._audyssey.set_multieq(setting=setting)
```


