### PR TITLE
Check for param.text before modifying it

### DIFF
--- a/denonavr/audyssey.py
+++ b/denonavr/audyssey.py
@@ -106,7 +106,7 @@ class Audyssey:
             if param.get("name") == "multeq":
                 self.multeq = MULTI_EQ_MAP.get(param.text)
             elif param.get("name") == "dynamiceq":
-                self.dynamiceq = bool(int(param.text))
+                self.dynamiceq = bool(int(param.text)) if param.text else None
             elif param.get("name") == "reflevoffset":
                 # Reference level offset can only be used with DynamicEQ
                 if self.dynamiceq is False:


### PR DESCRIPTION
Fix for https://github.com/scarface-4711/denonavr/issues/170

If param.text for dynamiceq is None then set self.dynamiceq to None (not False).  This is consistent with what will happen with the other attributes when their respective param.text is None:  `MULTI_EQ_MAP.get(param.text)`