### PR TITLE
Fix connectivity issues

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -1084,7 +1084,7 @@ class DenonAVR:
                 root = self.get_status_xml(self._urls.deviceinfo,
                                            suppress_errors=True)
             except (ValueError, requests.exceptions.RequestException):
-                self._receiver_type = None
+                continue
             else:
                 # First test by CommApiVers
                 try:
@@ -1096,7 +1096,7 @@ class DenonAVR:
                 except AttributeError:
                     # AttributeError occurs when ModelName tag is not found.
                     # In this case there is no AVR-X device
-                    self._receiver_type = None
+                    continue
 
                 # if first test did not find AVR-X device, check by model name
                 if self._receiver_type is None:
@@ -1109,7 +1109,7 @@ class DenonAVR:
                     except AttributeError:
                         # AttributeError occurs when ModelName tag is not found
                         # In this case there is no AVR-X device
-                        self._receiver_type = None
+                        continue
 
         # Set ports and update method
         if self._receiver_type is None:


### PR DESCRIPTION
See https://github.com/home-assistant/core/issues/43670 and elsewhere.

I was wrong about race conditions.  However, if `_get_receiver_sources` fails it was mutating the `self._receiver_type` which caused lots of other requests to fail, timeout 403 etc.

Still not sure why receivers were actually "locking up" - could not recreate even sending batches of 2000 updates with 50 in parallel.  However, during big requests I was able to observe the device info endpoint request time rising from 8ms to 3.3s

We may want to revisit `ensure_configuration` since it still does have a lot of blocking IO that HA doesn't like.

