### PR TITLE
added friendly_name for AVR receivers

### DIFF
--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -324,7 +324,9 @@ class DenonAVRDeviceInfo:
                 "Unable to get device information of host {}, Device is in a "
                 "corrupted state. Disconnect and reconnect power to the device"
                 " and try again.".format(self.api.host), command)
-
+            
+        if self.friendly_name is None and "friendlyName" in device_info:
+            self.friendly_name = device_info["friendlyName"]
         self.manufacturer = device_info["manufacturer"]
         self.model_name = device_info["modelName"]
         self.serial_number = device_info["serialNumber"]

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -324,7 +324,7 @@ class DenonAVRDeviceInfo:
                 "Unable to get device information of host {}, Device is in a "
                 "corrupted state. Disconnect and reconnect power to the device"
                 " and try again.".format(self.api.host), command)
-            
+
         if self.friendly_name is None and "friendlyName" in device_info:
             self.friendly_name = device_info["friendlyName"]
         self.manufacturer = device_info["manufacturer"]


### PR DESCRIPTION
fixes the folowwing error in home-assistant 2021.5.2 and denonavr 0.10.7:
ERROR (MainThread) [homeassistant.components.denonavr.receiver] Missing receiver information: manufacturer 'DENON', name 'None', model 'AVR-1912', type 'avr'

tested and working with home-assistant 2021.5.2