### PR TITLE
Fixed All Zone Stereo nog getting turned off

### DIFF
--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -223,7 +223,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
             return
 
         if self.sound_mode == ALL_ZONE_STEREO:
-            self._async_set_all_zone_stereo(False)
+            await self._async_set_all_zone_stereo(False)
         # For selection of sound mode other names then at receiving sound modes
         # have to be used
         # Therefore source mapping is needed to get sound_mode


### PR DESCRIPTION
I was having this weird issue where ALL ZONE STEREO was not being turned off, unless I power cycled the received. Manually calling the `MNZST OFF` command via the Home Assistant service call does work and correctly turn off the all zone stereo.

**NOTE**: Haven't actually tested this change just yet
**EDIT**: Just tested and confirmed it works 
