### PR TITLE
Fix issue where callback methods weren't marked as async

### DIFF
--- a/denonavr/audyssey.py
+++ b/denonavr/audyssey.py
@@ -70,7 +70,7 @@ class DenonAVRAudyssey(DenonAVRFoundation):
 
         self._is_setup = True
 
-    def _sound_detail_callback(self, zone: str, event: str, parameter: str):
+    async def _sound_detail_callback(self, zone: str, event: str, parameter: str):
         """Handle a sound detail change event."""
         if self._device.zone != zone:
             return

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -87,7 +87,7 @@ class DenonAVRDeviceInfo:
         else:
             raise ValueError("Invalid zone {}".format(self.zone))
 
-    def _power_callback(self, zone: str, event: str, value: str) -> None:
+    async def _power_callback(self, zone: str, event: str, value: str) -> None:
         """Handle a power change event."""
         if self.zone == zone:
             self._power = value

--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -116,7 +116,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
 
             self._is_setup = True
 
-    def _soundmode_callback(self, zone: str, event: str, value: str) -> None:
+    async def _soundmode_callback(self, zone: str, event: str, value: str) -> None:
         """Handle a sound mode change event."""
         if self._device.zone != zone:
             return

--- a/denonavr/tonecontrol.py
+++ b/denonavr/tonecontrol.py
@@ -64,7 +64,7 @@ class DenonAVRToneControl(DenonAVRFoundation):
 
         self._is_setup = True
 
-    def _sound_detail_callback(self, zone: str, event: str, parameter: str):
+    async def _sound_detail_callback(self, zone: str, event: str, parameter: str):
         """Handle a sound detail change event."""
         if self._device.zone != zone:
             return

--- a/denonavr/volume.py
+++ b/denonavr/volume.py
@@ -66,7 +66,7 @@ class DenonAVRVolume(DenonAVRFoundation):
 
         self._is_setup = True
 
-    def _volume_callback(self, zone: str, event: str, value: str) -> None:
+    async def _volume_callback(self, zone: str, event: str, value: str) -> None:
         """Handle a volume change event."""
         if self._device.zone != zone:
             return
@@ -78,7 +78,7 @@ class DenonAVRVolume(DenonAVRFoundation):
             fraction = (0.1 * float(value[2]))
             self._volume = -80.0 + whole_number + fraction
 
-    def _mute_callback(self, zone: str, event: str, value: str) -> None:
+    async def _mute_callback(self, zone: str, event: str, value: str) -> None:
         """Handle a muting change event."""
         if self._device.zone != zone:
             return


### PR DESCRIPTION
Discovered a small bug while working on the HA integration. After removing support for synchronous callbacks, there were a few that were not marked `async`. Everything still 'worked' but it was logging an exception about awaiting something that wasn't awaitable.