### PR TITLE
Update media state via telnet interface

### DIFF
--- a/denonavr/api.py
+++ b/denonavr/api.py
@@ -624,9 +624,10 @@ class DenonAVRTelnetApi:
                         err
                     )
 
-    def send_command(self, command: str) -> None:
-        """Send a telnet command to the receiver."""
-        self._protocol.write("{}\r".format(command))
+    def send_commands(self, *commands: str) -> None:
+        """Send telnet commands to the receiver."""
+        for command in commands:
+            self._protocol.write("{}\r".format(command))
 
     ##############
     # Properties #

--- a/denonavr/audyssey.py
+++ b/denonavr/audyssey.py
@@ -65,12 +65,12 @@ class DenonAVRAudyssey(DenonAVRFoundation):
             self._device.api.add_appcommand0300_update_tag(tag)
 
         self._device.telnet_api.register_callback(
-            "PS", self._sound_detail_callback
+            "PS", self._async_sound_detail_callback
         )
 
         self._is_setup = True
 
-    async def _sound_detail_callback(
+    async def _async_sound_detail_callback(
             self,
             zone: str,
             event: str,

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -129,7 +129,7 @@ PLAYING_SOURCES = {
     "Internet Radio", "Favorites", "SpotifyConnect", "Flickr",
     "TUNER", "NET/USB", "HDRADIO", "Music Server", "NETWORK", "NET"}
 NETAUDIO_SOURCES = {
-    "Online Music", "Media Server", "iPod/USB", "Bluetooth",
+    "AirPlay", "Online Music", "Media Server", "iPod/USB", "Bluetooth",
     "Internet Radio", "Favorites", "SpotifyConnect", "Flickr",
     "NET/USB", "Music Server", "NETWORK", "NET"}
 TUNER_SOURCES = {"Tuner", "TUNER"}

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -124,14 +124,16 @@ SOUND_MODE_MAPPING = {
     ALL_ZONE_STEREO: ["ALL ZONE STEREO"]}
 
 # Receiver sources
-PLAYING_SOURCES = (
+PLAYING_SOURCES = {
     "Online Music", "Media Server", "iPod/USB", "Bluetooth",
     "Internet Radio", "Favorites", "SpotifyConnect", "Flickr",
-    "TUNER", "NET/USB", "HDRADIO", "Music Server", "NETWORK", "NET")
-NETAUDIO_SOURCES = (
+    "TUNER", "NET/USB", "HDRADIO", "Music Server", "NETWORK", "NET"}
+NETAUDIO_SOURCES = {
     "Online Music", "Media Server", "iPod/USB", "Bluetooth",
     "Internet Radio", "Favorites", "SpotifyConnect", "Flickr",
-    "NET/USB", "Music Server", "NETWORK", "NET")
+    "NET/USB", "Music Server", "NETWORK", "NET"}
+TUNER_SOURCES = {"Tuner", "TUNER"}
+HDTUNER_SOURCES = {"HD Radio", "HDRADIO"}
 
 # Image URLs
 STATIC_ALBUM_URL = "http://{host}:{port}/img/album%20art_S.png"
@@ -261,7 +263,7 @@ ZONE3_URLS = ReceiverURLs(
     command_play=COMMAND_PLAY)
 
 # Telnet Commands
-TELNET_EVENTS = ["HD", "MS", "MU", "MV", "NS", "PS", "PW", "SI", "SS", "TF"]
+TELNET_EVENTS = {"HD", "MS", "MU", "MV", "NS", "PS", "PW", "SI", "SS", "TF"}
 
 # States
 POWER_ON = "ON"

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -135,7 +135,7 @@ NETAUDIO_SOURCES = (
 
 # Image URLs
 STATIC_ALBUM_URL = "http://{host}:{port}/img/album%20art_S.png"
-ALBUM_COVERS_URL = "http://{host}:{port}/NetAudio/art.asp-jpg?{time}"
+ALBUM_COVERS_URL = "http://{host}:{port}/NetAudio/art.asp-jpg?{hash}"
 
 # General URLs
 APPCOMMAND_URL = "/goform/AppCommand.xml"
@@ -261,7 +261,7 @@ ZONE3_URLS = ReceiverURLs(
     command_play=COMMAND_PLAY)
 
 # Telnet Commands
-TELNET_EVENTS = ["PW", "MV", "MU", "SI", "MS", "PS"]
+TELNET_EVENTS = ["HD", "MS", "MU", "MV", "NS", "PS", "PW", "SI", "SS", "TF"]
 
 # States
 POWER_ON = "ON"

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -221,6 +221,10 @@ class DenonAVR(DenonAVRFoundation):
     def send_get_command(self, request: str) -> str:
         """Send HTTP GET command to Denon AVR receiver...for compatibility."""
 
+    def send_telnet_commands(self, *commands: str) -> None:
+        """Send telnet commands to the receiver."""
+        self._device.telnet_api.send_commands(*commands)
+
     def register_callback(
         self,
         event: str,

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -87,7 +87,7 @@ class DenonAVRDeviceInfo:
         else:
             raise ValueError("Invalid zone {}".format(self.zone))
 
-    async def _power_callback(
+    async def _async_power_callback(
             self,
             zone: str,
             event: str,
@@ -96,7 +96,7 @@ class DenonAVRDeviceInfo:
         if self.zone == zone:
             self._power = parameter
 
-    def get_own_zone(self):
+    def get_own_zone(self) -> str:
         """
         Get zone from actual instance.
 
@@ -126,7 +126,7 @@ class DenonAVRDeviceInfo:
             self.api.add_appcommand_update_tag(
                 AppCommands.GetAllZonePowerStatus)
 
-            self.telnet_api.register_callback("PW", self._power_callback)
+            self.telnet_api.register_callback("PW", self._async_power_callback)
 
             self._is_setup = True
 
@@ -368,7 +368,7 @@ class DenonAVRDeviceInfo:
     async def async_update_power(
             self,
             global_update: bool = False,
-            cache_id: Optional[Hashable] = None):
+            cache_id: Optional[Hashable] = None) -> None:
         """Update power status of device."""
         if self.use_avr_2016_update is True:
             await self.async_update_power_appcommand(
@@ -382,7 +382,7 @@ class DenonAVRDeviceInfo:
     async def async_update_power_appcommand(
             self,
             global_update: bool = False,
-            cache_id: Optional[Hashable] = None):
+            cache_id: Optional[Hashable] = None) -> None:
         """Update power status from AppCommand.xml."""
         power_appcommand = AppCommands.GetAllZonePowerStatus
         try:
@@ -416,7 +416,7 @@ class DenonAVRDeviceInfo:
 
     async def async_update_power_status_xml(
             self,
-            cache_id: Optional[Hashable] = None):
+            cache_id: Optional[Hashable] = None) -> None:
         """Update power status from status xml."""
         # URLs to be scanned
         urls = [self.urls.status]

--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -30,7 +30,7 @@ from .foundation import DenonAVRFoundation
 
 _LOGGER = logging.getLogger(__name__)
 
-_MEDIA_UPDATE_INTERVAL = 10
+_MEDIA_UPDATE_INTERVAL = 5
 
 
 def lower_string(value: Optional[str]) -> Optional[str]:

--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -245,7 +245,7 @@ class DenonAVRInput(DenonAVRFoundation):
 
     def _update_netaudio(self) -> None:
         """Update netaudio information."""
-        self._device.telnet_api.send_command("NSE")
+        self._device.telnet_api.send_commands("NSE")
         self._schedule_netaudio_update()
 
     async def _async_netaudio_callback(
@@ -285,8 +285,7 @@ class DenonAVRInput(DenonAVRFoundation):
 
     def _update_tuner(self) -> None:
         """Update tuner information."""
-        self._device.telnet_api.send_command("TFAN?")
-        self._device.telnet_api.send_command("TFANNAME?")
+        self._device.telnet_api.send_commands("TFAN?", "TFANNAME?")
         self._schedule_tuner_update()
 
     async def _async_tuner_callback(
@@ -330,7 +329,7 @@ class DenonAVRInput(DenonAVRFoundation):
 
     def _update_hdtuner(self) -> None:
         """Update HD tuner information."""
-        self._device.telnet_api.send_command("HD?")
+        self._device.telnet_api.send_commands("HD?")
         self._schedule_hdtuner_update()
 
     async def _async_hdtuner_callback(

--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -111,12 +111,12 @@ class DenonAVRSoundMode(DenonAVRFoundation):
 
             self._device.telnet_api.register_callback(
                 "MS",
-                self._soundmode_callback
+                self._async_soundmode_callback
             )
 
             self._is_setup = True
 
-    async def _soundmode_callback(
+    async def _async_soundmode_callback(
             self,
             zone: str,
             event: str,

--- a/denonavr/tonecontrol.py
+++ b/denonavr/tonecontrol.py
@@ -59,12 +59,12 @@ class DenonAVRToneControl(DenonAVRFoundation):
 
         self._device.telnet_api.register_callback(
             "PS",
-            self._sound_detail_callback
+            self._async_sound_detail_callback
         )
 
         self._is_setup = True
 
-    async def _sound_detail_callback(
+    async def _async_sound_detail_callback(
             self,
             zone: str,
             event: str,

--- a/denonavr/volume.py
+++ b/denonavr/volume.py
@@ -61,12 +61,14 @@ class DenonAVRVolume(DenonAVRFoundation):
         for tag in self.appcommand_attrs:
             self._device.api.add_appcommand_update_tag(tag)
 
-        self._device.telnet_api.register_callback("MV", self._volume_callback)
-        self._device.telnet_api.register_callback("MU", self._mute_callback)
+        self._device.telnet_api.register_callback(
+            "MV", self._async_volume_callback)
+        self._device.telnet_api.register_callback(
+            "MU", self._async_mute_callback)
 
         self._is_setup = True
 
-    async def _volume_callback(
+    async def _async_volume_callback(
             self,
             zone: str,
             event: str,
@@ -82,7 +84,7 @@ class DenonAVRVolume(DenonAVRFoundation):
             fraction = 0.1 * float(parameter[2])
             self._volume = -80.0 + whole_number + fraction
 
-    async def _mute_callback(
+    async def _async_mute_callback(
             self,
             zone: str,
             event: str,


### PR DESCRIPTION
This PR enabled the telnet interface to update the media state. It still polls the state, but it sends and receives just a couple of characters over the existing connection and should be more efficient than using the HTTP interface.
Additionally, it updates the list of input functions when a potential change is discovered (like enabling/disabling and renaming sources).

@dcmeglio @bdraco @starkillerOG feel free to test it 😄 