### PR TITLE
Add additional sound modes from Marantz NR1711

### DIFF
--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -213,7 +213,7 @@ SOUND_MODE_MAPPING = {
         "DOLBY AUDIO - DD+   + DSUR",
         "DOLBY AUDIO - DOLBY DIGITAL",
         "DOLBY AUDIO-DSUR",
-        "DOLBY AUDIO-DD+DSUR"
+        "DOLBY AUDIO-DD+DSUR",
     ],
     "DTS SURROUND": [
         "DTS SURROUND",

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -213,6 +213,7 @@ SOUND_MODE_MAPPING = {
         "DOLBY AUDIO - DD+   + DSUR",
         "DOLBY AUDIO - DOLBY DIGITAL",
         "DOLBY AUDIO-DSUR",
+        "DOLBY AUDIO-DD+DSUR"
     ],
     "DTS SURROUND": [
         "DTS SURROUND",


### PR DESCRIPTION
Fixes `2023-03-19 02:28:51.478 WARNING (MainThread) [denonavr.soundmode] Not able to match sound mode: 'DOLBY AUDIO-DD+DSUR', assuming 'DOLBY DIGITAL'.`
