### PR TITLE
Use telnet commands to interact with the receiver when the connection is healthy

### DIFF
--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -45,6 +45,24 @@ ReceiverURLs = namedtuple(
         "command_play",
     ],
 )
+TelnetCommands = namedtuple(
+    "TelnetCommands",
+    [
+        "command_sel_src",
+        "command_fav_src",
+        "command_power_on",
+        "command_power_standby",
+        "command_volume_up",
+        "command_volume_down",
+        "command_set_volume",
+        "command_mute_on",
+        "command_mute_off",
+        "command_sel_sound_mode",
+        "command_set_all_zone_stereo",
+        "command_pause",
+        "command_play",
+    ],
+)
 
 # AVR-X search patterns
 DEVICEINFO_AVR_X_PATTERN = re.compile(
@@ -395,6 +413,54 @@ ZONE3_URLS = ReceiverURLs(
 
 # Telnet Commands
 TELNET_EVENTS = {"HD", "MS", "MU", "MV", "NS", "PS", "PW", "SI", "SS", "TF"}
+
+DENONAVR_TELNET_COMMANDS = TelnetCommands(
+    command_sel_src="SI",
+    command_fav_src="ZM",
+    command_power_on="PWON",
+    command_power_standby="PWSTANDBY",
+    command_volume_up="MVUP",
+    command_volume_down="MVDOWN",
+    command_set_volume="MV{volume:02d}",
+    command_mute_on="MUON",
+    command_mute_off="MUOFF",
+    command_sel_sound_mode="MS",
+    command_set_all_zone_stereo="MN",
+    command_pause="NS9B",
+    command_play="NS9A",
+)
+
+ZONE2_TELNET_COMMANDS = TelnetCommands(
+    command_sel_src="Z2",
+    command_fav_src="Z2",
+    command_power_on="Z2ON",
+    command_power_standby="Z2OFF",
+    command_volume_up="Z2UP",
+    command_volume_down="Z2DOWN",
+    command_set_volume="Z2{volume:02d}",
+    command_mute_on="Z2MUON",
+    command_mute_off="Z2MUOFF",
+    command_sel_sound_mode="MS",
+    command_set_all_zone_stereo="MN",
+    command_pause="NS9B",
+    command_play="NS9A",
+)
+
+ZONE3_TELNET_COMMANDS = TelnetCommands(
+    command_sel_src="Z3",
+    command_fav_src="Z3",
+    command_power_on="Z3ON",
+    command_power_standby="Z3OFF",
+    command_volume_up="Z3UP",
+    command_volume_down="Z3DOWN",
+    command_set_volume="Z3{volume:02d}",
+    command_mute_on="Z3MUON",
+    command_mute_off="Z3MUOFF",
+    command_sel_sound_mode="MS",
+    command_set_all_zone_stereo="MN",
+    command_pause="NS9B",
+    command_play="NS9A",
+)
 
 # States
 POWER_ON = "ON"

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -226,9 +226,9 @@ class DenonAVR(DenonAVRFoundation):
     def send_get_command(self, request: str) -> str:
         """Send HTTP GET command to Denon AVR receiver...for compatibility."""
 
-    def send_telnet_commands(self, *commands: str) -> None:
+    def send_telnet_commands(self, *commands: str) -> bool:
         """Send telnet commands to the receiver."""
-        self._device.telnet_api.send_commands(*commands)
+        return self._device.telnet_api.send_commands(*commands)
 
     def register_callback(
         self, event: str, callback: Callable[[str, str, str], Awaitable[None]]
@@ -441,7 +441,7 @@ class DenonAVR(DenonAVRFoundation):
         return self._device.telnet_api.connected
 
     @property
-    def telnet_healthy(self) -> Optional[bool]:
+    def telnet_healthy(self) -> bool:
         """Return True if telnet connection is healthy."""
         return self._device.telnet_api.healthy
 

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -25,6 +25,7 @@ from .const import (
     AVR_X,
     AVR_X_2016,
     DENON_ATTR_SETATTR,
+    DENONAVR_TELNET_COMMANDS,
     DENONAVR_URLS,
     DESCRIPTION_TYPES,
     DEVICEINFO_AVR_X_PATTERN,
@@ -33,11 +34,14 @@ from .const import (
     VALID_RECEIVER_TYPES,
     VALID_ZONES,
     ZONE2,
+    ZONE2_TELNET_COMMANDS,
     ZONE2_URLS,
     ZONE3,
+    ZONE3_TELNET_COMMANDS,
     ZONE3_URLS,
     ReceiverType,
     ReceiverURLs,
+    TelnetCommands,
 )
 from .exceptions import (
     AvrForbiddenError,
@@ -69,6 +73,9 @@ class DenonAVRDeviceInfo:
     receiver: Optional[ReceiverType] = attr.ib(
         validator=attr.validators.optional(attr.validators.in_(VALID_RECEIVER_TYPES)),
         default=None,
+    )
+    telnet_commands: TelnetCommands = attr.ib(
+        validator=attr.validators.instance_of(TelnetCommands), init=False
     )
     urls: ReceiverURLs = attr.ib(
         validator=attr.validators.instance_of(ReceiverURLs), init=False
@@ -102,10 +109,13 @@ class DenonAVRDeviceInfo:
         """Initialize special attributes and callbacks."""
         # URLs depending from value of self.zone attribute
         if self.zone == MAIN_ZONE:
+            self.telnet_commands = DENONAVR_TELNET_COMMANDS
             self.urls = DENONAVR_URLS
         elif self.zone == ZONE2:
+            self.telnet_commands = ZONE2_TELNET_COMMANDS
             self.urls = ZONE2_URLS
         elif self.zone == ZONE3:
+            self.telnet_commands = ZONE3_TELNET_COMMANDS
             self.urls = ZONE3_URLS
         else:
             raise ValueError("Invalid zone {}".format(self.zone))

--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -993,10 +993,13 @@ class DenonAVRInput(DenonAVRFoundation):
         # Create command URL and send command via HTTP GET
         if linp in self._favorite_func_list:
             command_url = self._device.urls.command_fav_src + linp
+            telnet_command = self._device.telnet_commands.command_fav_src + linp
         else:
             command_url = self._device.urls.command_sel_src + linp
-
-        await self._device.api.async_get_command(command_url)
+            telnet_command = self._device.telnet_commands.command_sel_src + linp
+        success = self._device.telnet_api.send_commands(telnet_command)
+        if not success:
+            await self._device.api.async_get_command(command_url)
 
     async def async_toggle_play_pause(self) -> None:
         """Toggle play pause media player."""
@@ -1017,15 +1020,24 @@ class DenonAVRInput(DenonAVRFoundation):
             if self._state == STATE_PLAYING:
                 _LOGGER.info("Already playing, play command not sent")
                 return
-
-            await self._device.api.async_get_command(self._device.urls.command_play)
+            success = self._device.telnet_api.send_commands(
+                self._device.telnet_commands.command_play
+            )
+            if not success:
+                await self._device.api.async_get_command(self._device.urls.command_play)
             self._state = STATE_PLAYING
 
     async def async_pause(self) -> None:
         """Send pause command to receiver command via HTTP post."""
         # Use pause command only for sources which support NETAUDIO
         if self._input_func in self._netaudio_func_list:
-            await self._device.api.async_get_command(self._device.urls.command_pause)
+            success = self._device.telnet_api.send_commands(
+                self._device.telnet_commands.command_play
+            )
+            if not success:
+                await self._device.api.async_get_command(
+                    self._device.urls.command_pause
+                )
             self._state = STATE_PAUSED
 
     async def async_previous_track(self) -> None:

--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -264,8 +264,10 @@ class DenonAVRInput(DenonAVRFoundation):
 
     def _update_netaudio(self) -> None:
         """Update netaudio information."""
-        self._device.telnet_api.send_commands("NSE")
-        self._schedule_netaudio_update()
+        if self._device.telnet_api.send_commands("NSE"):
+            self._schedule_netaudio_update()
+        else:
+            self._stop_media_update()
 
     async def _async_netaudio_callback(
         self, zone: str, event: str, parameter: str
@@ -304,8 +306,10 @@ class DenonAVRInput(DenonAVRFoundation):
 
     def _update_tuner(self) -> None:
         """Update tuner information."""
-        self._device.telnet_api.send_commands("TFAN?", "TFANNAME?")
-        self._schedule_tuner_update()
+        if self._device.telnet_api.send_commands("TFAN?", "TFANNAME?"):
+            self._schedule_tuner_update()
+        else:
+            self._stop_media_update()
 
     async def _async_tuner_callback(
         self, zone: str, event: str, parameter: str
@@ -345,8 +349,10 @@ class DenonAVRInput(DenonAVRFoundation):
 
     def _update_hdtuner(self) -> None:
         """Update HD tuner information."""
-        self._device.telnet_api.send_commands("HD?")
-        self._schedule_hdtuner_update()
+        if self._device.telnet_api.send_commands("HD?"):
+            self._schedule_hdtuner_update()
+        else:
+            self._stop_media_update()
 
     async def _async_hdtuner_callback(
         self, zone: str, event: str, parameter: str

--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -230,12 +230,16 @@ class DenonAVRSoundMode(DenonAVRFoundation):
         Calls command to activate/deactivate the mode
         """
         command_url = self._device.urls.command_set_all_zone_stereo
+        telnet_command = self._device.telnet_commands.command_set_all_zone_stereo
         if zst_on:
             command_url += "ZST ON"
+            telnet_command += "ZST ON"
         else:
             command_url += "ZST OFF"
-
-        await self._device.api.async_get_command(command_url)
+            telnet_command += "ZST OFF"
+        success = self._device.telnet_api.send_commands(telnet_command)
+        if not success:
+            await self._device.api.async_get_command(command_url)
 
     ##############
     # Properties #
@@ -292,8 +296,13 @@ class DenonAVRSoundMode(DenonAVRFoundation):
         # Therefore source mapping is needed to get sound_mode
         # Create command URL and send command via HTTP GET
         command_url = self._device.urls.command_sel_sound_mode + sound_mode
+        telnet_command = (
+            self._device.telnet_commands.command_sel_sound_mode + sound_mode
+        )
         # sent command
-        await self._device.api.async_get_command(command_url)
+        success = self._device.telnet_api.send_commands(telnet_command)
+        if not success:
+            await self._device.api.async_get_command(command_url)
 
 
 def sound_mode_factory(instance: DenonAVRFoundation) -> DenonAVRSoundMode:

--- a/denonavr/volume.py
+++ b/denonavr/volume.py
@@ -143,11 +143,23 @@ class DenonAVRVolume(DenonAVRFoundation):
     ##########
     async def async_volume_up(self) -> None:
         """Volume up receiver via HTTP get command."""
-        await self._device.api.async_get_command(self._device.urls.command_volume_up)
+        success = self._device.telnet_api.send_commands(
+            self._device.telnet_commands.command_volume_up
+        )
+        if not success:
+            await self._device.api.async_get_command(
+                self._device.urls.command_volume_up
+            )
 
     async def async_volume_down(self) -> None:
         """Volume down receiver via HTTP get command."""
-        await self._device.api.async_get_command(self._device.urls.command_volume_down)
+        success = self._device.telnet_api.send_commands(
+            self._device.telnet_commands.command_volume_down
+        )
+        if not success:
+            await self._device.api.async_get_command(
+                self._device.urls.command_volume_down
+            )
 
     async def async_set_volume(self, volume: float) -> None:
         """
@@ -161,17 +173,34 @@ class DenonAVRVolume(DenonAVRFoundation):
 
         # Round volume because only values which are a multi of 0.5 are working
         volume = round(volume * 2) / 2.0
-
-        await self._device.api.async_get_command(
-            self._device.urls.command_set_volume.format(volume=volume)
+        success = self._device.telnet_api.send_commands(
+            self._device.telnet_commands.command_set_volume.format(
+                volume=int(volume + 80)
+            )
         )
+        if not success:
+            await self._device.api.async_get_command(
+                self._device.urls.command_set_volume.format(volume=volume)
+            )
 
     async def async_mute(self, mute: bool) -> None:
         """Mute receiver via HTTP get command."""
         if mute:
-            await self._device.api.async_get_command(self._device.urls.command_mute_on)
+            success = self._device.telnet_api.send_commands(
+                self._device.telnet_commands.command_mute_on
+            )
+            if not success:
+                await self._device.api.async_get_command(
+                    self._device.urls.command_mute_on
+                )
         else:
-            await self._device.api.async_get_command(self._device.urls.command_mute_off)
+            success = self._device.telnet_api.send_commands(
+                self._device.telnet_commands.command_mute_off
+            )
+            if not success:
+                await self._device.api.async_get_command(
+                    self._device.urls.command_mute_off
+                )
 
 
 def volume_factory(instance: DenonAVRFoundation) -> DenonAVRVolume:

--- a/tests/test_denonavr.py
+++ b/tests/test_denonavr.py
@@ -250,7 +250,7 @@ class TestMainFunctions:
     async def test_protocol_connected(self):
         """Connected after connection made."""
         proto = DenonAVRTelnetProtocol(None, None)
-        transport = AsyncMock()
+        transport = mock.Mock(is_closing=lambda: False)
         proto.connection_made(transport)
 
         assert proto.connected
@@ -263,10 +263,19 @@ class TestMainFunctions:
         assert not proto.connected
 
     @pytest.mark.asyncio
+    async def test_protocol_closing(self):
+        """Not connected when connection is closing."""
+        proto = DenonAVRTelnetProtocol(None, None)
+        transport = mock.Mock(is_closing=lambda: True)
+        proto.connection_made(transport)
+
+        assert not proto.connected
+
+    @pytest.mark.asyncio
     async def test_protocol_writes_to_transport(self):
         """Write writes to transport."""
         proto = DenonAVRTelnetProtocol(None, None)
-        transport = mock.Mock()
+        transport = mock.Mock(is_closing=lambda: False)
         proto.connection_made(transport)
 
         proto.write("abc")
@@ -289,7 +298,7 @@ class TestMainFunctions:
         """Read callback triggered for CR terminated message."""
         data_received_mock = mock.Mock()
         proto = DenonAVRTelnetProtocol(data_received_mock, None)
-        transport = mock.Mock()
+        transport = mock.Mock(is_closing=lambda: False)
         proto.connection_made(transport)
         proto.data_received(b"abc\r")
 
@@ -300,7 +309,7 @@ class TestMainFunctions:
         """Read callback not triggered for non CR terminated message."""
         data_received_mock = mock.Mock()
         proto = DenonAVRTelnetProtocol(data_received_mock, None)
-        transport = mock.Mock()
+        transport = mock.Mock(is_closing=lambda: False)
         proto.connection_made(transport)
         proto.data_received(b"abc")
 
@@ -311,7 +320,7 @@ class TestMainFunctions:
         """Connection lost triggers callback."""
         conn_lost_mock = mock.Mock()
         proto = DenonAVRTelnetProtocol(None, conn_lost_mock)
-        transport = mock.Mock()
+        transport = mock.Mock(is_closing=lambda: False)
         proto.connection_made(transport)
         proto.connection_lost(Exception())
 


### PR DESCRIPTION
With this PR telnet commands are used to interact with the receiver when telnet is connected and the connection is healthy. Otherwise, HTTP commands are used.


@dcmeglio @bdraco @starkillerOG If you would like to test this, please feel invited to do so 😄 