### PR TITLE
Introduce soundmode `AURO2DSURR`

### DIFF
--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -250,7 +250,8 @@ SOUND_MODE_MAPPING = {
         "DTS-HD + DSUR",
         "DTS:X MSTR",
     ],
-    "AURO3D": ["AURO-3D", "AURO-2D SURROUND"],
+    "AURO3D": ["AURO-3D"],
+    "AURO2DSURR": ["AURO-2D SURROUND"],
     "MCH STEREO": [
         "MULTI CH STEREO",
         "MULTI_CH_STEREO",


### PR DESCRIPTION
This PR introduces soundmode `AURO2DSURR` and moves raw soundmode `AURO-2D SURROUND` to it.

Fixes #250 