### PR TITLE
Fix mapping of main zone `power` attribute when using telnet

### DIFF
--- a/denonavr/api.py
+++ b/denonavr/api.py
@@ -585,9 +585,7 @@ class DenonAVRTelnetApi:
             else:
                 zone = ZONE3
 
-            if parameter in ("ON", "OFF"):
-                event = "PW"
-            elif parameter in TELNET_SOURCES:
+            if parameter in TELNET_SOURCES:
                 event = "SI"
             elif parameter.isdigit():
                 event = "MV"

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -413,13 +413,27 @@ ZONE3_URLS = ReceiverURLs(
 )
 
 # Telnet Commands
-TELNET_EVENTS = {"HD", "MS", "MU", "MV", "NS", "PS", "PW", "SI", "SS", "TF"}
+TELNET_EVENTS = {
+    "HD",
+    "MS",
+    "MU",
+    "MV",
+    "NS",
+    "PS",
+    "PW",
+    "SI",
+    "SS",
+    "TF",
+    "ZM",
+    "Z2",
+    "Z3",
+}
 
 DENONAVR_TELNET_COMMANDS = TelnetCommands(
     command_sel_src="SI",
     command_fav_src="ZM",
-    command_power_on="PWON",
-    command_power_standby="PWSTANDBY",
+    command_power_on="ZMON",
+    command_power_standby="ZMOFF",
     command_volume_up="MVUP",
     command_volume_down="MVDOWN",
     command_set_volume="MV{volume:02d}",
@@ -467,6 +481,7 @@ ZONE3_TELNET_COMMANDS = TelnetCommands(
 POWER_ON = "ON"
 POWER_OFF = "OFF"
 POWER_STANDBY = "STANDBY"
+POWER_STATES = [POWER_ON, POWER_OFF, POWER_STANDBY]
 STATE_ON = "on"
 STATE_OFF = "off"
 STATE_PLAYING = "playing"

--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -184,8 +184,15 @@ class DenonAVRInput(DenonAVRFoundation):
         for tag in self.appcommand_attrs:
             self._device.api.add_appcommand_update_tag(tag)
 
+        power_event = "ZM"
+        if self._device.zone == ZONE2:
+            power_event = "Z2"
+        elif self._device.zone == ZONE3:
+            power_event = "Z3"
+        self._device.telnet_api.register_callback(
+            power_event, self._async_power_callback
+        )
         self._device.telnet_api.register_callback("SI", self._async_input_callback)
-        self._device.telnet_api.register_callback("PW", self._async_power_callback)
         self._device.telnet_api.register_callback("NS", self._async_netaudio_callback)
         self._device.telnet_api.register_callback("TF", self._async_tuner_callback)
         self._device.telnet_api.register_callback("HD", self._async_hdtuner_callback)

--- a/tests/test_denonavr.py
+++ b/tests/test_denonavr.py
@@ -518,7 +518,7 @@ class TestMainFunctions:
             protocol.connection_made(transport)
             self.future = asyncio.Future()
             self.denon.register_callback("ALL", self._callback)
-            protocol.data_received(b"PWON\r")
+            protocol.data_received(b"ZMON\r")
             await self.future
             assert self.denon.power == "ON"
 
@@ -545,9 +545,9 @@ class TestMainFunctions:
             protocol.connection_made(transport)
             self.future = asyncio.Future()
             self.denon.register_callback("ALL", self._callback)
-            protocol.data_received(b"PWSTANDBY\r")
+            protocol.data_received(b"ZMOFF\r")
             await self.future
-            assert self.denon.power == "STANDBY"
+            assert self.denon.power == "OFF"
 
     @pytest.mark.asyncio
     async def test_volume_min(self, httpx_mock: HTTPXMock):


### PR DESCRIPTION
This PR fixes the mapping of  main zone `power` attribute when using telnet.
Before the power status of main zone was always on, if any zone was switched on. 