### PR TITLE
Add some dolby pl2 mappings

### DIFF
--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -186,6 +186,7 @@ SOUND_MODE_MAPPING = {
         "DOLBY PL2 CINEMA",
         "DOLBY PL2 C",
         "DOLBY PL2 X MOVIE",
+        "DOLBY PL2 MOVIE",
     ],
     "GAME": [
         "PLII GAME",
@@ -193,6 +194,7 @@ SOUND_MODE_MAPPING = {
         "DOLBY PL2 GAME",
         "DOLBY PL2 G",
         "DOLBY PL2 X GAME",
+        "DOLBY PLII GAME",
     ],
     "AUTO": ["None"],
     "STANDARD": ["None2"],


### PR DESCRIPTION
I assume this is right..not really sure but seems doable with the log messages provided

Fixes #268 

Also adds one I saw
```
Logger: denonavr.soundmode
Source: components/denonavr/media_player.py:362
First occurred: January 1, 2024 at 1:23:02 PM (1 occurrences)
Last logged: January 1, 2024 at 1:23:02 PM

Not able to match sound mode: 'DOLBY PLII GAME', assuming 'DOLBY DIGITAL'.
```