### PR TITLE
Fix wrong utf-8 encoding with `ftfy`

### DIFF
--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -8,13 +8,13 @@ This module implements the handler for input functions of Denon AVR receivers.
 """
 
 import asyncio
-import html
 import logging
 from copy import deepcopy
 from typing import Dict, Hashable, List, Optional, Set, Tuple
 
 import attr
 import httpx
+from ftfy import fix_text
 
 from .appcommand import AppCommands
 from .const import (
@@ -56,11 +56,11 @@ def lower_string(value: Optional[str]) -> Optional[str]:
     return str(value).lower()
 
 
-def unescape_string(value: Optional[str]) -> Optional[str]:
-    """Perform HTML unescape on value."""
+def fix_string(value: Optional[str]) -> Optional[str]:
+    """Fix errors in string like unescaped HTML and wrong utf-8 encoding."""
     if value is None:
         return value
-    return html.unescape(str(value)).strip("\x00").strip("\x01").strip()
+    return fix_text(str(value)).strip()
 
 
 def set_input_func(
@@ -143,22 +143,22 @@ class DenonAVRInput(DenonAVRFoundation):
     )
 
     _artist: Optional[str] = attr.ib(
-        converter=attr.converters.optional(unescape_string), default=None
+        converter=attr.converters.optional(fix_string), default=None
     )
     _album: Optional[str] = attr.ib(
-        converter=attr.converters.optional(unescape_string), default=None
+        converter=attr.converters.optional(fix_string), default=None
     )
     _band: Optional[str] = attr.ib(
-        converter=attr.converters.optional(unescape_string), default=None
+        converter=attr.converters.optional(fix_string), default=None
     )
     _title: Optional[str] = attr.ib(
-        converter=attr.converters.optional(unescape_string), default=None
+        converter=attr.converters.optional(fix_string), default=None
     )
     _frequency: Optional[str] = attr.ib(
-        converter=attr.converters.optional(unescape_string), default=None
+        converter=attr.converters.optional(fix_string), default=None
     )
     _station: Optional[str] = attr.ib(
-        converter=attr.converters.optional(unescape_string), default=None
+        converter=attr.converters.optional(fix_string), default=None
     )
     _image_url: Optional[str] = attr.ib(
         converter=attr.converters.optional(str), default=None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "asyncstdlib>=3.10.2",
     "attrs>=21.2.0",
     "defusedxml>=0.7.1",
+    "ftfy>=6.1.1",
     "httpx>=0.23.1",
     "netifaces>=0.11.0",
     'async-timeout>=4.0.2; python_version < "3.11"',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asyncstdlib>=3.10.2
 attrs>=21.2.0
 defusedxml>=0.7.1
+ftfy>=6.1.1
 httpx>=0.21.0
 netifaces>=0.11.0
 async-timeout>=4.0.2; python_version < "3.11"


### PR DESCRIPTION
This PR fixes wrong utf-8 encodings in strings returned from the receiver.