### PR TITLE
Wait for confirmations from the receiver when sending telnet messages

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -226,6 +226,10 @@ class DenonAVR(DenonAVRFoundation):
     def send_get_command(self, request: str) -> str:
         """Send HTTP GET command to Denon AVR receiver...for compatibility."""
 
+    async def async_send_telnet_commands(self, *commands: str) -> bool:
+        """Send telnet commands to the receiver."""
+        return await self._device.telnet_api.async_send_commands(*commands)
+
     def send_telnet_commands(self, *commands: str) -> bool:
         """Send telnet commands to the receiver."""
         return self._device.telnet_api.send_commands(*commands)

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -513,13 +513,15 @@ class DenonAVRDeviceInfo:
 
     async def async_power_on(self) -> None:
         """Turn on receiver via HTTP get command."""
-        success = self.telnet_api.send_commands(self.telnet_commands.command_power_on)
+        success = await self.telnet_api.async_send_commands(
+            self.telnet_commands.command_power_on
+        )
         if not success:
             await self.api.async_get_command(self.urls.command_power_on)
 
     async def async_power_off(self) -> None:
         """Turn off receiver via HTTP get command."""
-        success = self.telnet_api.send_commands(
+        success = await self.telnet_api.async_send_commands(
             self.telnet_commands.command_power_standby
         )
         if not success:

--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -1001,7 +1001,7 @@ class DenonAVRInput(DenonAVRFoundation):
         else:
             command_url = self._device.urls.command_sel_src + linp
             telnet_command = self._device.telnet_commands.command_sel_src + linp
-        success = self._device.telnet_api.send_commands(telnet_command)
+        success = await self._device.telnet_api.async_send_commands(telnet_command)
         if not success:
             await self._device.api.async_get_command(command_url)
 
@@ -1024,7 +1024,7 @@ class DenonAVRInput(DenonAVRFoundation):
             if self._state == STATE_PLAYING:
                 _LOGGER.info("Already playing, play command not sent")
                 return
-            success = self._device.telnet_api.send_commands(
+            success = await self._device.telnet_api.async_send_commands(
                 self._device.telnet_commands.command_play
             )
             if not success:
@@ -1035,7 +1035,7 @@ class DenonAVRInput(DenonAVRFoundation):
         """Send pause command to receiver command via HTTP post."""
         # Use pause command only for sources which support NETAUDIO
         if self._input_func in self._netaudio_func_list:
-            success = self._device.telnet_api.send_commands(
+            success = await self._device.telnet_api.async_send_commands(
                 self._device.telnet_commands.command_play
             )
             if not success:

--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -237,7 +237,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
         else:
             command_url += "ZST OFF"
             telnet_command += "ZST OFF"
-        success = self._device.telnet_api.send_commands(telnet_command)
+        success = await self._device.telnet_api.async_send_commands(telnet_command)
         if not success:
             await self._device.api.async_get_command(command_url)
 
@@ -303,7 +303,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
             self._device.telnet_commands.command_sel_sound_mode + sound_mode
         )
         # sent command
-        success = self._device.telnet_api.send_commands(telnet_command)
+        success = await self._device.telnet_api.async_send_commands(telnet_command)
         if not success:
             await self._device.api.async_get_command(command_url)
 

--- a/denonavr/volume.py
+++ b/denonavr/volume.py
@@ -143,7 +143,7 @@ class DenonAVRVolume(DenonAVRFoundation):
     ##########
     async def async_volume_up(self) -> None:
         """Volume up receiver via HTTP get command."""
-        success = self._device.telnet_api.send_commands(
+        success = await self._device.telnet_api.async_send_commands(
             self._device.telnet_commands.command_volume_up
         )
         if not success:
@@ -153,7 +153,7 @@ class DenonAVRVolume(DenonAVRFoundation):
 
     async def async_volume_down(self) -> None:
         """Volume down receiver via HTTP get command."""
-        success = self._device.telnet_api.send_commands(
+        success = await self._device.telnet_api.async_send_commands(
             self._device.telnet_commands.command_volume_down
         )
         if not success:
@@ -173,7 +173,7 @@ class DenonAVRVolume(DenonAVRFoundation):
 
         # Round volume because only values which are a multi of 0.5 are working
         volume = round(volume * 2) / 2.0
-        success = self._device.telnet_api.send_commands(
+        success = await self._device.telnet_api.async_send_commands(
             self._device.telnet_commands.command_set_volume.format(
                 volume=int(volume + 80)
             )
@@ -186,7 +186,7 @@ class DenonAVRVolume(DenonAVRFoundation):
     async def async_mute(self, mute: bool) -> None:
         """Mute receiver via HTTP get command."""
         if mute:
-            success = self._device.telnet_api.send_commands(
+            success = await self._device.telnet_api.async_send_commands(
                 self._device.telnet_commands.command_mute_on
             )
             if not success:
@@ -194,7 +194,7 @@ class DenonAVRVolume(DenonAVRFoundation):
                     self._device.urls.command_mute_on
                 )
         else:
-            success = self._device.telnet_api.send_commands(
+            success = await self._device.telnet_api.async_send_commands(
                 self._device.telnet_commands.command_mute_off
             )
             if not success:


### PR DESCRIPTION
Some telnet commands like changing the sound mode block the receiver for while. In the meantime they ignore any sent commands.
With this PR the telnet interface locks the telnet send command until it receives a confirmation message. The lock also expires after 2 seconds without an confirmation. 

Fixes #274 