### PR TITLE
Don't wait for confirmation when sending volume up/down telnet commands

### DIFF
--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -273,7 +273,7 @@ class DenonAVRInput(DenonAVRFoundation):
     def _update_netaudio(self) -> None:
         """Update netaudio information."""
         if self._device.telnet_available:
-            self._device.telnet_api.send_commands("NSE")
+            self._device.telnet_api.send_commands("NSE", skip_confirmation=True)
             self._schedule_netaudio_update()
         else:
             self._stop_media_update()
@@ -316,7 +316,9 @@ class DenonAVRInput(DenonAVRFoundation):
     def _update_tuner(self) -> None:
         """Update tuner information."""
         if self._device.telnet_available:
-            self._device.telnet_api.send_commands("TFAN?", "TFANNAME?")
+            self._device.telnet_api.send_commands(
+                "TFAN?", "TFANNAME?", skip_confirmation=True
+            )
             self._schedule_tuner_update()
         else:
             self._stop_media_update()
@@ -360,7 +362,7 @@ class DenonAVRInput(DenonAVRFoundation):
     def _update_hdtuner(self) -> None:
         """Update HD tuner information."""
         if self._device.telnet_available:
-            self._device.telnet_api.send_commands("HD?")
+            self._device.telnet_api.send_commands("HD?", skip_confirmation=True)
             self._schedule_hdtuner_update()
         else:
             self._stop_media_update()

--- a/denonavr/volume.py
+++ b/denonavr/volume.py
@@ -148,7 +148,7 @@ class DenonAVRVolume(DenonAVRFoundation):
         """Volume up receiver via HTTP get command."""
         if self._device.telnet_available:
             await self._device.telnet_api.async_send_commands(
-                self._device.telnet_commands.command_volume_up
+                self._device.telnet_commands.command_volume_up, skip_confirmation=True
             )
         else:
             await self._device.api.async_get_command(
@@ -159,7 +159,7 @@ class DenonAVRVolume(DenonAVRFoundation):
         """Volume down receiver via HTTP get command."""
         if self._device.telnet_available:
             await self._device.telnet_api.async_send_commands(
-                self._device.telnet_commands.command_volume_down
+                self._device.telnet_commands.command_volume_down, skip_confirmation=True
             )
         else:
             await self._device.api.async_get_command(


### PR DESCRIPTION
Telnet API does not wait for confirmations when sending volume up/down commands to decrease latency. 
Additionally, the background update commands also don't wait for confirmations.
These commands do not block the telnet interface.