### PR TITLE
Set timeout on _send_confirmation_timeout

### DIFF
--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -873,6 +873,7 @@ def set_api_timeout(
     instance._device.api.timeout = value
     instance._device.api.read_timeout = max(value, 15.0)
     instance._device.telnet_api.timeout = value
+    instance._device.telnet_api._send_confirmation_timeout = value
     return value
 
 


### PR DESCRIPTION
The timeout for acknowledgements via Telnet commands will now use the value specified in  the `timeout` parameter in the `DenonAVR` class,