### PR TITLE
Fix lookup maps which might cause telnet callback exceptions

### DIFF
--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -1350,12 +1350,29 @@ ECO_MODE_MAP_LABELS = {value: key for key, value in ECO_MODE_MAP.items()}
 EcoModes = Literal["On", "Auto", "Off"]
 """Eco Modes."""
 
-EffectSpeakers = Literal["Floor", "Height + Floor"]
+EffectSpeakers = Literal[
+    "Floor",
+    "Front",
+    "Front Height",
+    "Front Wide",
+    "Front Height + Front Wide",
+    "Height + Floor",
+    "Surround Back",
+    "Surround Back + Front Height",
+    "Surround Back + Front Wide",
+]
 """Effect Speakers."""
 
 EFFECT_SPEAKER_SELECTION_MAP = {
     "Floor": "FL",
+    "Front": "FR",
+    "Front Height": "FH",
+    "Front Wide": "FW",
+    "Front Height + Front Wide": "HW",
     "Height + Floor": "HF",
+    "Surround Back": "SB",
+    "Surround Back + Front Height": "BH",
+    "Surround Back + Front Wide": "BW",
 }
 EFFECT_SPEAKER_SELECTION_MAP_LABELS = {
     value: key for key, value in EFFECT_SPEAKER_SELECTION_MAP.items()


### PR DESCRIPTION
While testing I found two error messages in my logs. This PR should fix the issue.

```
2025-05-01 19:45:08,901 - denonavr.api - DEBUG - Incoming Telnet message: PSSWL OFF
2025-05-01 19:45:08,901 - denonavr.api - ERROR - 192.168.178.250: Event callback caused an unhandled exception: 'OFF'
```
```
2025-05-01 19:45:09,414 - denonavr.api - DEBUG - Incoming Telnet message: PSSP:SB
2025-05-01 19:45:09,415 - denonavr.api - ERROR - 192.168.178.250: Event callback caused an unhandled exception: 'SB'
2025-05-01 19:45:09,415 - denonavr.api - ERROR - 192.168.178.250: Event callback caused an unhandled exception: 'SB'
2025-05-01 19:45:09,415 - denonavr.api - ERROR - 192.168.178.250: Event callback caused an unhandled exception: 'SB'
```

@henrikwidlund could you have a look please?