### PR TITLE
Do not recognise `QUICK` as a sound mode

### DIFF
--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -229,6 +229,10 @@ class DenonAVRSoundMode(DenonAVRFoundation):
         if self._device.zone != zone:
             return
 
+        # QUICK is not a sound mode
+        if parameter.startswith("QUICK"):
+            return
+
         self._sound_mode_raw = parameter
 
     async def _async_neural_x_callback(


### PR DESCRIPTION
Since #323 `MSQUICK ?` commands are sent to the receiver. The reponse is something like `MSQUICK1`. Reponses starting with `QUICK` are no sound modes. This PR ensures that they are no falsely recognised as such.