### PR TITLE
Fix a bug with mapping SMART (Marantz) as a sound mode.

### DIFF
--- a/denonavr/api.py
+++ b/denonavr/api.py
@@ -587,6 +587,7 @@ class DenonAVRTelnetApi:
             "PSSWL ?",
             "SSTTR ?",
             "MSQUICK ?",
+            "MSSMART ?",
             "STBY?",
             "SLP?",
             "VSAUDIO ?",

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -90,6 +90,8 @@ ReceiverURLs = namedtuple(
         "command_hdmi_audio_decode",
         "command_quick_select_mode",
         "command_quick_select_memory",
+        "command_smart_select_mode",  # Marantz
+        "command_smart_select_memory",  # Marantz
         "command_auto_standby",
         "command_sleep",
         "command_center_spread",
@@ -183,6 +185,8 @@ TelnetCommands = namedtuple(
         "command_hdmi_audio_decode",
         "command_quick_select_mode",
         "command_quick_select_memory",
+        "command_smart_select_mode",  # Marantz
+        "command_smart_select_memory",  # Marantz
         "command_auto_standby",
         "command_sleep",
         "command_center_spread",
@@ -541,7 +545,11 @@ COMMAND_DIALOG_ENHANCER = "/goform/formiPhoneAppDirect.xml?PSDEH%20{level}"
 COMMAND_HDMI_OUTPUT = "/goform/formiPhoneAppDirect.xml?VSMONI{output}"
 COMMAND_HDMI_AUDIO_DECODE = "/goform/formiPhoneAppDirect.xml?VSAUDIO%20{mode}"
 COMMAND_QUICK_SELECT_MODE = "/goform/formiPhoneAppDirect.xml?MSQUICK{number}"
-COMMAND_QUICK_SELECT_MEMORY = "/goform/formiPhoneAppDirect.xml?MSQUICK{number}"
+COMMAND_QUICK_SELECT_MEMORY = "/goform/formiPhoneAppDirect.xml?MSQUICK{number}%20MEMORY"
+COMMAND_SMART_SELECT_MODE = "/goform/formiPhoneAppDirect.xml?MSSMART{number}"  # Marantz
+COMMAND_SMART_SELECT_MEMORY = (
+    "/goform/formiPhoneAppDirect.xml?MSSMART{number}%20MEMORY"  # Marantz
+)
 COMMAND_AUTO_STANDBY = "/goform/formiPhoneAppDirect.xml?STBY{mode}"
 COMMAND_SLEEP = "/goform/formiPhoneAppDirect.xml?SLP{value}"
 COMMAND_CENTER_SPREAD = "/goform/formiPhoneAppDirect.xml?PSCES%20{mode}"
@@ -658,6 +666,8 @@ DENONAVR_URLS = ReceiverURLs(
     command_hdmi_audio_decode=COMMAND_HDMI_AUDIO_DECODE,
     command_quick_select_mode=COMMAND_QUICK_SELECT_MODE,
     command_quick_select_memory=COMMAND_QUICK_SELECT_MODE,
+    command_smart_select_mode=COMMAND_SMART_SELECT_MODE,  # Marantz
+    command_smart_select_memory=COMMAND_SMART_SELECT_MEMORY,  # Marantz
     command_auto_standby=COMMAND_AUTO_STANDBY,
     command_sleep=COMMAND_SLEEP,
     command_center_spread=COMMAND_CENTER_SPREAD,
@@ -751,6 +761,8 @@ ZONE2_URLS = ReceiverURLs(
     command_hdmi_audio_decode=COMMAND_HDMI_AUDIO_DECODE,
     command_quick_select_mode=COMMAND_QUICK_SELECT_MODE,
     command_quick_select_memory=COMMAND_QUICK_SELECT_MEMORY,
+    command_smart_select_mode=COMMAND_SMART_SELECT_MODE,  # Marantz
+    command_smart_select_memory=COMMAND_SMART_SELECT_MEMORY,  # Marantz
     command_auto_standby=COMMAND_AUTO_STANDBY,
     command_sleep=COMMAND_SLEEP,
     command_center_spread=COMMAND_CENTER_SPREAD,
@@ -844,6 +856,8 @@ ZONE3_URLS = ReceiverURLs(
     command_hdmi_audio_decode=COMMAND_HDMI_AUDIO_DECODE,
     command_quick_select_mode=COMMAND_QUICK_SELECT_MODE,
     command_quick_select_memory=COMMAND_QUICK_SELECT_MEMORY,
+    command_smart_select_mode=COMMAND_SMART_SELECT_MODE,  # Marantz
+    command_smart_select_memory=COMMAND_SMART_SELECT_MEMORY,  # Marantz
     command_auto_standby=COMMAND_AUTO_STANDBY,
     command_sleep=COMMAND_SLEEP,
     command_center_spread=COMMAND_CENTER_SPREAD,
@@ -992,6 +1006,8 @@ DENONAVR_TELNET_COMMANDS = TelnetCommands(
     command_hdmi_audio_decode="VSAUDIO {mode}",
     command_quick_select_mode="MSQUICK{number}",
     command_quick_select_memory="MSQUICK{number} MEMORY",
+    command_smart_select_mode="MSSMART{number}",  # Marantz
+    command_smart_select_memory="MSSMART{number} MEMORY",  # Marantz
     command_auto_standby="STBY{mode}",
     command_sleep="SLP{value}",
     command_center_spread="PSCES {mode}",
@@ -1083,6 +1099,8 @@ ZONE2_TELNET_COMMANDS = TelnetCommands(
     command_hdmi_audio_decode="VSAUDIO {mode}",
     command_quick_select_mode="MSQUICK{number}",
     command_quick_select_memory="MSQUICK{number} MEMORY",
+    command_smart_select_mode="MSSMART{number}",  # Marantz
+    command_smart_select_memory="MSSMART{number} MEMORY",  # Marantz
     command_auto_standby="STBY{mode}",
     command_sleep="SLP{value}",
     command_center_spread="PSCES {mode}",
@@ -1174,6 +1192,8 @@ ZONE3_TELNET_COMMANDS = TelnetCommands(
     command_hdmi_audio_decode="VSAUDIO {mode}",
     command_quick_select_mode="MSQUICK{number}",
     command_quick_select_memory="MSQUICK{number} MEMORY",
+    command_smart_select_mode="MSSMART{number}",  # Marantz
+    command_smart_select_memory="MSSMART{number} MEMORY",  # Marantz
     command_auto_standby="STBY{mode}",
     command_sleep="SLP{value}",
     command_center_spread="PSCES {mode}",

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -1397,15 +1397,19 @@ class DenonAVRDeviceInfo:
             raise AvrCommandError("Quick select number must be between 1 and 5")
 
         if self.telnet_available:
+            if "denon" in self.manufacturer.lower():
+                command = self.telnet_commands.command_quick_select_memory
+            else:
+                command = self.telnet_commands.command_smart_select_memory
             await self.telnet_api.async_send_commands(
-                self.telnet_commands.command_quick_select_mode.format(
-                    number=quick_select_number
-                )
+                command.format(number=quick_select_number)
             )
         else:
-            await self.api.async_get_command(
-                self.urls.command_quick_select_mode.format(number=quick_select_number)
-            )
+            if "denon" in self.manufacturer.lower():
+                command = self.urls.command_quick_select_mode
+            else:
+                command = self.urls.command_smart_select_mode
+            await self.api.async_get_command(command.format(number=quick_select_number))
 
     async def async_quick_select_memory(self, quick_select_number: int) -> None:
         """
@@ -1417,15 +1421,19 @@ class DenonAVRDeviceInfo:
             raise AvrCommandError("Quick select number must be between 1 and 5")
 
         if self.telnet_available:
+            if "denon" in self.manufacturer.lower():
+                command = self.telnet_commands.command_quick_select_mode
+            else:
+                command = self.telnet_commands.command_smart_select_mode
             await self.telnet_api.async_send_commands(
-                self.telnet_commands.command_quick_select_memory.format(
-                    number=quick_select_number
-                )
+                command.format(number=quick_select_number)
             )
         else:
-            await self.api.async_get_command(
-                self.urls.command_quick_select_memory.format(number=quick_select_number)
-            )
+            if "denon" in self.manufacturer.lower():
+                command = self.urls.command_quick_select_memory
+            else:
+                command = self.urls.command_smart_select_memory
+            await self.api.async_get_command(command.format(number=quick_select_number))
 
     async def async_delay_up(self) -> None:
         """Delay up on receiver via HTTP get command."""

--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -229,8 +229,8 @@ class DenonAVRSoundMode(DenonAVRFoundation):
         if self._device.zone != zone:
             return
 
-        # QUICK is not a sound mode
-        if parameter.startswith("QUICK"):
+        # QUICK/SMART are not sound modes
+        if parameter.startswith("QUICK") or parameter.startswith("SMART"):
             return
 
         self._sound_mode_raw = parameter


### PR DESCRIPTION
Also adds support for storing QUICK commands on Marantz devices.

Fixes #336