### PR TITLE
Add support for HDMI CEC and Marantz specific commands

### DIFF
--- a/denonavr/api.py
+++ b/denonavr/api.py
@@ -475,6 +475,7 @@ class DenonAVRTelnetApi:
 
     host: str = attr.ib(converter=str, default="localhost")
     timeout: float = attr.ib(converter=float, default=2.0)
+    is_denon: bool = attr.ib(converter=bool, default=True)
     _connection_enabled: bool = attr.ib(default=False)
     _last_message_time: float = attr.ib(default=-1.0)
     _connect_lock: asyncio.Lock = attr.ib(default=attr.Factory(asyncio.Lock))
@@ -550,7 +551,7 @@ class DenonAVRTelnetApi:
         self._last_message_time = time.monotonic()
         self._schedule_monitor()
         # Trigger update of all attributes
-        await self.async_send_commands(
+        commands = [
             "ZM?",
             "SI?",
             "MV?",
@@ -613,6 +614,14 @@ class DenonAVRTelnetApi:
             "PSRSTR ?",
             "PSGEQ ?",
             "PSHEQ ?",
+        ]
+        if not self.is_denon:
+            commands.append("PSMDAX ?")
+            commands.append("PSDACFIL ?")
+            commands.append("ILB ?")
+            commands.append("SSHOS ?")
+        await self.async_send_commands(
+            *commands,
             skip_confirmation=True,
         )
 

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -114,6 +114,14 @@ ReceiverURLs = namedtuple(
         "command_panel_and_volume_lock",
         "command_graphic_eq",
         "command_headphone_eq",
+        "command_denon_hdmi_cec_on",
+        "command_denon_hdmi_cec_off",
+        "command_marantz_hdmi_cec_on",
+        "command_marantz_hdmi_cec_off",
+        "command_mdax",  # Marantz Only
+        "command_dac_filter",  # Marantz Only
+        "command_illumination",  # Marantz Only
+        "command_auto_lip_sync",  # Marantz Only
     ],
 )
 TelnetCommands = namedtuple(
@@ -209,6 +217,14 @@ TelnetCommands = namedtuple(
         "command_panel_and_volume_lock",
         "command_graphic_eq",
         "command_headphone_eq",
+        "command_denon_hdmi_cec_on",
+        "command_denon_hdmi_cec_off",
+        "command_marantz_hdmi_cec_on",
+        "command_marantz_hdmi_cec_off",
+        "command_mdax",  # Marantz Only
+        "command_dac_filter",  # Marantz Only
+        "command_illumination",  # Marantz Only
+        "command_auto_lip_sync",  # Marantz Only
     ],
 )
 
@@ -572,6 +588,16 @@ COMMAND_PANEL_LOCK = "/goform/formiPhoneAppDirect.xml?SYPANEL%20LOCK%20{mode}"
 COMMAND_PANEL_AND_VOLUME_LOCK = "/goform/formiPhoneAppDirect.xml?SYPANEL+V%20LOCK%20ON"
 COMMAND_GRAPHIC_EQ = "/goform/formiPhoneAppDirect.xml?PSGEQ%20{mode}"
 COMMAND_HEADPHONE_EQ = "/goform/formiPhoneAppDirect.xml?PSHEQ%20{mode}"
+COMMAND_DENON_HDMI_CEC_ON = "/goform/formiPhoneAppDirect.xml?RCKSK0410826"
+COMMAND_DENON_HDMI_CEC_OFF = "/goform/formiPhoneAppDirect.xml?RCKSK0410827"
+COMMAND_MARANTZ_HDMI_CEC_ON = "/goform/formiPhoneAppDirect.xml?RCRC51608408"
+COMMAND_MARANTZ_HDMI_CEC_OFF = "/goform/formiPhoneAppDirect.xml?RCRC51608409"
+COMMAND_MDAX = "/goform/formiPhoneAppDirect.xml?PSMDAX%20{mode}"  # Marantz Only
+COMMAND_DAC_FILTER = "/goform/formiPhoneAppDirect.xml?PSDACFIL%20{mode}"  # Marantz Only
+COMMAND_ILLUMINATION = "/goform/formiPhoneAppDirect.xml?ILB%20{mode}"  # Marantz Only
+COMMAND_AUTO_LIP_SYNC = (
+    "/goform/formiPhoneAppDirect.xml?SSHOSALS%20{mode}"  # Marantz Only
+)
 
 # Zone 2 URLs
 STATUS_Z2_URL = "/goform/formZone2_Zone2XmlStatus.xml"
@@ -690,6 +716,14 @@ DENONAVR_URLS = ReceiverURLs(
     command_panel_and_volume_lock=COMMAND_PANEL_AND_VOLUME_LOCK,
     command_graphic_eq=COMMAND_GRAPHIC_EQ,
     command_headphone_eq=COMMAND_HEADPHONE_EQ,
+    command_denon_hdmi_cec_on=COMMAND_DENON_HDMI_CEC_ON,
+    command_denon_hdmi_cec_off=COMMAND_DENON_HDMI_CEC_OFF,
+    command_marantz_hdmi_cec_on=COMMAND_MARANTZ_HDMI_CEC_ON,
+    command_marantz_hdmi_cec_off=COMMAND_MARANTZ_HDMI_CEC_OFF,
+    command_mdax=COMMAND_MDAX,  # Marantz Only
+    command_dac_filter=COMMAND_DAC_FILTER,  # Marantz Only
+    command_illumination=COMMAND_ILLUMINATION,  # Marantz Only
+    command_auto_lip_sync=COMMAND_AUTO_LIP_SYNC,  # Marantz Only
 )
 
 ZONE2_URLS = ReceiverURLs(
@@ -785,6 +819,14 @@ ZONE2_URLS = ReceiverURLs(
     command_panel_and_volume_lock=COMMAND_PANEL_AND_VOLUME_LOCK,
     command_graphic_eq=COMMAND_GRAPHIC_EQ,
     command_headphone_eq=COMMAND_HEADPHONE_EQ,
+    command_denon_hdmi_cec_on=COMMAND_DENON_HDMI_CEC_ON,
+    command_denon_hdmi_cec_off=COMMAND_DENON_HDMI_CEC_OFF,
+    command_marantz_hdmi_cec_on=COMMAND_MARANTZ_HDMI_CEC_ON,
+    command_marantz_hdmi_cec_off=COMMAND_MARANTZ_HDMI_CEC_OFF,
+    command_mdax=COMMAND_MDAX,  # Marantz Only
+    command_dac_filter=COMMAND_DAC_FILTER,  # Marantz Only
+    command_illumination=COMMAND_ILLUMINATION,  # Marantz Only
+    command_auto_lip_sync=COMMAND_AUTO_LIP_SYNC,  # Marantz Only
 )
 
 ZONE3_URLS = ReceiverURLs(
@@ -880,6 +922,14 @@ ZONE3_URLS = ReceiverURLs(
     command_panel_and_volume_lock=COMMAND_PANEL_AND_VOLUME_LOCK,
     command_graphic_eq=COMMAND_GRAPHIC_EQ,
     command_headphone_eq=COMMAND_HEADPHONE_EQ,
+    command_denon_hdmi_cec_on=COMMAND_DENON_HDMI_CEC_ON,
+    command_denon_hdmi_cec_off=COMMAND_DENON_HDMI_CEC_OFF,
+    command_marantz_hdmi_cec_on=COMMAND_MARANTZ_HDMI_CEC_ON,
+    command_marantz_hdmi_cec_off=COMMAND_MARANTZ_HDMI_CEC_OFF,
+    command_mdax=COMMAND_MDAX,  # Marantz Only
+    command_dac_filter=COMMAND_DAC_FILTER,  # Marantz Only
+    command_illumination=COMMAND_ILLUMINATION,  # Marantz Only
+    command_auto_lip_sync=COMMAND_AUTO_LIP_SYNC,  # Marantz Only
 )
 
 # Telnet Events
@@ -891,6 +941,7 @@ TELNET_EVENTS = {
     "DIM",
     "ECO",
     "HD",
+    "ILB",  # Marantz Only
     "MN",
     "MS",
     "MU",
@@ -1030,6 +1081,14 @@ DENONAVR_TELNET_COMMANDS = TelnetCommands(
     command_panel_and_volume_lock="SYPANEL+V LOCK ON",
     command_graphic_eq="PSGEQ {mode}",
     command_headphone_eq="PSHEQ {mode}",
+    command_denon_hdmi_cec_on="RCKSK0410826",
+    command_denon_hdmi_cec_off="RCKSK0410827",
+    command_marantz_hdmi_cec_on="RCRC51608408",
+    command_marantz_hdmi_cec_off="RCRC51608409",
+    command_mdax="PSMDAX {mode}",  # Marantz Only
+    command_dac_filter="PSDACFIL {mode}",  # Marantz Only
+    command_illumination="ILB {mode}",  # Marantz Only
+    command_auto_lip_sync="SSHOSALS {mode}",  # Marantz Only
 )
 
 ZONE2_TELNET_COMMANDS = TelnetCommands(
@@ -1123,6 +1182,14 @@ ZONE2_TELNET_COMMANDS = TelnetCommands(
     command_panel_and_volume_lock="SYPANEL+V LOCK ON",
     command_graphic_eq="PSGEQ {mode}",
     command_headphone_eq="PSHEQ {mode}",
+    command_denon_hdmi_cec_on="RCKSK0410826",
+    command_denon_hdmi_cec_off="RCKSK0410827",
+    command_marantz_hdmi_cec_on="RCRC51608408",
+    command_marantz_hdmi_cec_off="RCRC51608409",
+    command_mdax="PSMDAX {mode}",  # Marantz Only
+    command_dac_filter="PSDACFIL {mode}",  # Marantz Only
+    command_illumination="ILB {mode}",  # Marantz Only
+    command_auto_lip_sync="SSHOSALS {mode}",  # Marantz Only
 )
 
 ZONE3_TELNET_COMMANDS = TelnetCommands(
@@ -1216,6 +1283,14 @@ ZONE3_TELNET_COMMANDS = TelnetCommands(
     command_panel_and_volume_lock="SYPANEL+V LOCK ON",
     command_graphic_eq="PSGEQ {mode}",
     command_headphone_eq="PSHEQ {mode}",
+    command_denon_hdmi_cec_on="RCKSK0410826",
+    command_denon_hdmi_cec_off="RCKSK0410827",
+    command_marantz_hdmi_cec_on="RCRC51608408",
+    command_marantz_hdmi_cec_off="RCRC51608409",
+    command_mdax="PSMDAX {mode}",  # Marantz Only
+    command_dac_filter="PSDACFIL {mode}",  # Marantz Only
+    command_illumination="ILB {mode}",  # Marantz Only
+    command_auto_lip_sync="SSHOSALS {mode}",  # Marantz Only
 )
 
 # States
@@ -1624,3 +1699,37 @@ VIDEO_PROCESSING_MODES_MAP = {
 VIDEO_PROCESSING_MODES_MAP_LABELS = {
     value: key for key, value in VIDEO_PROCESSING_MODES_MAP.items()
 }
+
+MDAXs = Literal["Off", "Low", "Medium", "High"]
+"""M-DAX Modes."""
+
+MDAX_MAP = {
+    "Off": "OFF",
+    "Low": "LOW",
+    "Medium": "MED",
+    "High": "HI",
+}
+MDAX_MAP_LABELS = {value: key for key, value in MDAX_MAP.items()}
+
+DACFilters = Literal["Mode 1", "Mode 2"]
+"""DAC Filter Modes."""
+
+DAC_FILTERS_MAP = {
+    "Mode 1": "MODE1",
+    "Mode 2": "MODE2",
+}
+
+DAC_FILTERS_MAP_LABELS = {value: key for key, value in DAC_FILTERS_MAP.items()}
+
+Illuminations = Literal["Auto", "Bright", "Dim", "Dark", "Off"]
+"""Illumination Modes."""
+
+ILLUMINATION_MAP = {
+    "Auto": "AUTO",
+    "Bright": "BRI",
+    "Dim": "DIM",
+    "Dark": "DAR",
+    "Off": "OFF",
+}
+
+ILLUMINATION_MAP_LABELS = {value: key for key, value in ILLUMINATION_MAP.items()}

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -27,6 +27,7 @@ from .const import (
     EcoModes,
     HDMIAudioDecodes,
     HDMIOutputs,
+    Illuminations,
     PanelLocks,
     RoomSizes,
     TransducerLPFs,
@@ -738,6 +739,26 @@ class DenonAVR(DenonAVRFoundation):
         """
         return self._device.headphone_eq
 
+    @property
+    def illumination(self) -> Optional[str]:
+        """
+        Return the illumination status for the device.
+
+        Only available on Marantz devices and when using Telnet.
+
+        Possible values are: "Auto", "Bright", "Dim", "Dark", "Off"
+        """
+        return self.illumination
+
+    @property
+    def auto_lip_sync(self) -> Optional[bool]:
+        """
+        Return the auto lip sync status for the device.
+
+        Only available on Marantz devices and when using Telnet.
+        """
+        return self.auto_lip_sync
+
     ##########
     # Getter #
     ##########
@@ -1210,3 +1231,43 @@ class DenonAVR(DenonAVRFoundation):
         :param quick_select_number: Quick select number to set. Valid values are 1-5.
         """
         await self._device.async_quick_select_memory(quick_select_number)
+
+    async def async_hdmi_cec_on(self) -> None:
+        """Turn on HDMI CEC on receiver via HTTP get command."""
+        await self._device.async_hdmi_cec_on()
+
+    async def async_hdmi_cec_off(self) -> None:
+        """Turn off HDMI CEC on receiver via HTTP get command."""
+        await self._device.async_hdmi_cec_off()
+
+    async def async_illumination(self, mode: Illuminations):
+        """
+        Set illumination mode on receiver via HTTP get command.
+
+        Only available for Marantz devices.
+        """
+        await self._device.async_illumination(mode)
+
+    async def async_auto_lip_sync_on(self) -> None:
+        """
+        Turn on auto lip sync on receiver via HTTP get command.
+
+        Only available on Marantz devices.
+        """
+        await self._device.async_auto_lip_sync_on()
+
+    async def async_auto_lip_sync_off(self) -> None:
+        """
+        Turn off auto lip sync on receiver via HTTP get command.
+
+        Only available on Marantz devices.
+        """
+        await self._device.async_auto_lip_sync_off()
+
+    async def async_auto_lip_sync_toggle(self) -> None:
+        """
+        Toggle auto lip sync on receiver via HTTP get command.
+
+        Only available on Marantz devices and when using Telnet.
+        """
+        await self._device.async_auto_lip_sync_toggle()

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -521,7 +521,7 @@ class DenonAVRDeviceInfo:
             self.telnet_api.register_callback("PS", self._async_graphic_eq_callback)
             self.telnet_api.register_callback("PS", self._async_headphone_eq_callback)
 
-            if not self.is_denon_avr:
+            if not self.is_denon:
                 self.telnet_api.register_callback(
                     "ILB", self._async_illumination_callback
                 )
@@ -772,7 +772,7 @@ class DenonAVRDeviceInfo:
 
         if device_info is None:
             self.manufacturer = "Denon"
-            self.telnet_api.is_denon = self.is_denon_avr
+            self.telnet_api.is_denon = self.is_denon
             self.model_name = "Unknown"
             self.serial_number = None
             _LOGGER.warning(
@@ -788,7 +788,7 @@ class DenonAVRDeviceInfo:
         if self.friendly_name is None and "friendlyName" in device_info:
             self.friendly_name = device_info["friendlyName"]
         self.manufacturer = device_info["manufacturer"]
-        self.telnet_api.is_denon = self.is_denon_avr
+        self.telnet_api.is_denon = self.is_denon
         self.model_name = device_info["modelName"]
         self.serial_number = device_info["serialNumber"]
 
@@ -1122,8 +1122,8 @@ class DenonAVRDeviceInfo:
         return self.telnet_api.connected and self.telnet_api.healthy
 
     @property
-    def is_denon_avr(self) -> bool:
-        """Return true if the receiver is a Denon AVR."""
+    def is_denon(self) -> bool:
+        """Return true if the receiver is a Denon device."""
         return "denon" in self.manufacturer.lower()
 
     ##########
@@ -1472,7 +1472,7 @@ class DenonAVRDeviceInfo:
             raise AvrCommandError("Quick select number must be between 1 and 5")
 
         if self.telnet_available:
-            if self.is_denon_avr:
+            if self.is_denon:
                 command = self.telnet_commands.command_quick_select_memory
             else:
                 command = self.telnet_commands.command_smart_select_memory
@@ -1480,7 +1480,7 @@ class DenonAVRDeviceInfo:
                 command.format(number=quick_select_number)
             )
         else:
-            if self.is_denon_avr:
+            if self.is_denon:
                 command = self.urls.command_quick_select_mode
             else:
                 command = self.urls.command_smart_select_mode
@@ -1496,7 +1496,7 @@ class DenonAVRDeviceInfo:
             raise AvrCommandError("Quick select number must be between 1 and 5")
 
         if self.telnet_available:
-            if self.is_denon_avr:
+            if self.is_denon:
                 command = self.telnet_commands.command_quick_select_mode
             else:
                 command = self.telnet_commands.command_smart_select_mode
@@ -1504,7 +1504,7 @@ class DenonAVRDeviceInfo:
                 command.format(number=quick_select_number)
             )
         else:
-            if self.is_denon_avr:
+            if self.is_denon:
                 command = self.urls.command_quick_select_memory
             else:
                 command = self.urls.command_smart_select_memory
@@ -1590,7 +1590,7 @@ class DenonAVRDeviceInfo:
 
     async def async_status(self) -> None:
         """Get status of receiver via HTTP get command."""
-        if not self.is_denon_avr:
+        if not self.is_denon:
             raise AvrCommandError("Status command is only supported for Denon devices")
 
         if self.telnet_available:
@@ -1893,13 +1893,13 @@ class DenonAVRDeviceInfo:
         if self.telnet_available:
             await self.telnet_api.async_send_commands(
                 self.telnet_commands.command_denon_hdmi_cec_on
-                if self.is_denon_avr
+                if self.is_denon
                 else self.urls.command_marantz_hdmi_cec_on
             )
         else:
             await self.api.async_get_command(
                 self.urls.command_denon_hdmi_cec_on
-                if self.is_denon_avr
+                if self.is_denon
                 else self.urls.command_marantz_hdmi_cec_on
             )
 
@@ -1908,13 +1908,13 @@ class DenonAVRDeviceInfo:
         if self.telnet_available:
             await self.telnet_api.async_send_commands(
                 self.telnet_commands.command_denon_hdmi_cec_off
-                if self.is_denon_avr
+                if self.is_denon
                 else self.urls.command_marantz_hdmi_cec_off
             )
         else:
             await self.api.async_get_command(
                 self.urls.command_denon_hdmi_cec_off
-                if self.is_denon_avr
+                if self.is_denon
                 else self.urls.command_marantz_hdmi_cec_off
             )
 
@@ -1924,7 +1924,7 @@ class DenonAVRDeviceInfo:
 
         Only available on Marantz devices.
         """
-        if self.is_denon_avr:
+        if self.is_denon:
             raise AvrCommandError("Illumination is only available for Marantz devices")
 
         if mode not in self._illuminations:
@@ -1946,7 +1946,7 @@ class DenonAVRDeviceInfo:
 
         Only available on Marantz devices.
         """
-        if self.is_denon_avr:
+        if self.is_denon:
             raise AvrCommandError("Auto lip sync is only available for Marantz devices")
 
         if self.telnet_available:
@@ -1964,7 +1964,7 @@ class DenonAVRDeviceInfo:
 
         Only available on Marantz devices.
         """
-        if self.is_denon_avr:
+        if self.is_denon:
             raise AvrCommandError("Auto lip sync is only available for Marantz devices")
 
         if self.telnet_available:
@@ -1982,7 +1982,7 @@ class DenonAVRDeviceInfo:
 
         Only available on Marantz devices and when using Telnet.
         """
-        if self.is_denon_avr:
+        if self.is_denon:
             raise AvrCommandError("Auto lip sync is only available for Marantz devices")
 
         if self._auto_lip_sync:

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -41,6 +41,8 @@ from .const import (
     ECO_MODE_MAP_LABELS,
     HDMI_OUTPUT_MAP,
     HDMI_OUTPUT_MAP_LABELS,
+    ILLUMINATION_MAP,
+    ILLUMINATION_MAP_LABELS,
     MAIN_ZONE,
     POWER_STATES,
     SETTINGS_MENU_STATES,
@@ -61,6 +63,7 @@ from .const import (
     EcoModes,
     HDMIAudioDecodes,
     HDMIOutputs,
+    Illuminations,
     PanelLocks,
     ReceiverType,
     ReceiverURLs,
@@ -218,6 +221,13 @@ class DenonAVRDeviceInfo:
         converter=attr.converters.optional(convert_on_off_bool), default=None
     )
     _headphone_eq: Optional[bool] = attr.ib(
+        converter=attr.converters.optional(convert_on_off_bool), default=None
+    )
+    _illumination: Optional[str] = attr.ib(
+        converter=attr.converters.optional(str), default=None
+    )
+    _illuminations = get_args(Illuminations)
+    _auto_lip_sync: Optional[bool] = attr.ib(
         converter=attr.converters.optional(convert_on_off_bool), default=None
     )
     _is_setup: bool = attr.ib(converter=bool, default=False, init=False)
@@ -422,6 +432,31 @@ class DenonAVRDeviceInfo:
 
         self._headphone_eq = parameter[4:]
 
+    async def _async_illumination_callback(
+        self, zone: str, event: str, parameter: str
+    ) -> None:
+        """Handle an illumination change event."""
+        if event != "ILB" or parameter[0:3] != "ILL":
+            return
+
+        self._illumination = ILLUMINATION_MAP_LABELS[parameter[4:]]
+
+    async def _async_auto_lip_sync_callback(
+        self, zone: str, event: str, parameter: str
+    ) -> None:
+        """Handle a auto lip sync change event."""
+        if event != "PS" or parameter[0:3] != "HOS":
+            return
+
+        if parameter[6:] == "HOSALS":
+            auto_lip_sync = parameter[5:]
+        elif parameter[3:] == "HOS":
+            auto_lip_sync = parameter[4:]
+        else:
+            return
+
+        self._auto_lip_sync = auto_lip_sync
+
     def get_own_zone(self) -> str:
         """
         Get zone from actual instance.
@@ -485,6 +520,14 @@ class DenonAVRDeviceInfo:
             self.telnet_api.register_callback("PS", self._async_audio_restorer_callback)
             self.telnet_api.register_callback("PS", self._async_graphic_eq_callback)
             self.telnet_api.register_callback("PS", self._async_headphone_eq_callback)
+
+            if not self.is_denon_avr:
+                self.telnet_api.register_callback(
+                    "ILB", self._async_illumination_callback
+                )
+                self.telnet_api.register_callback(
+                    "SS", self._async_auto_lip_sync_callback
+                )
 
             self._is_setup = True
             _LOGGER.debug("Finished device setup")
@@ -729,6 +772,7 @@ class DenonAVRDeviceInfo:
 
         if device_info is None:
             self.manufacturer = "Denon"
+            self.telnet_api.is_denon = self.is_denon_avr
             self.model_name = "Unknown"
             self.serial_number = None
             _LOGGER.warning(
@@ -744,6 +788,7 @@ class DenonAVRDeviceInfo:
         if self.friendly_name is None and "friendlyName" in device_info:
             self.friendly_name = device_info["friendlyName"]
         self.manufacturer = device_info["manufacturer"]
+        self.telnet_api.is_denon = self.is_denon_avr
         self.model_name = device_info["modelName"]
         self.serial_number = device_info["serialNumber"]
 
@@ -1052,9 +1097,34 @@ class DenonAVRDeviceInfo:
         return self._headphone_eq
 
     @property
+    def illumination(self) -> Optional[str]:
+        """
+        Return the illumination status for the device.
+
+        Only available on Marantz devices and when using Telnet.
+
+        Possible values are: "Auto", "Bright", "Dim", "Dark", "Off"
+        """
+        return self._illumination
+
+    @property
+    def auto_lip_sync(self) -> Optional[bool]:
+        """
+        Return the auto lip sync status for the device.
+
+        Only available on Marantz devices and when using Telnet.
+        """
+        return self._auto_lip_sync
+
+    @property
     def telnet_available(self) -> bool:
         """Return true if telnet is connected and healthy."""
         return self.telnet_api.connected and self.telnet_api.healthy
+
+    @property
+    def is_denon_avr(self) -> bool:
+        """Return true if the receiver is a Denon AVR."""
+        return "denon" in self.manufacturer.lower()
 
     ##########
     # Getter #
@@ -1402,7 +1472,7 @@ class DenonAVRDeviceInfo:
             raise AvrCommandError("Quick select number must be between 1 and 5")
 
         if self.telnet_available:
-            if "denon" in self.manufacturer.lower():
+            if self.is_denon_avr:
                 command = self.telnet_commands.command_quick_select_memory
             else:
                 command = self.telnet_commands.command_smart_select_memory
@@ -1410,7 +1480,7 @@ class DenonAVRDeviceInfo:
                 command.format(number=quick_select_number)
             )
         else:
-            if "denon" in self.manufacturer.lower():
+            if self.is_denon_avr:
                 command = self.urls.command_quick_select_mode
             else:
                 command = self.urls.command_smart_select_mode
@@ -1426,7 +1496,7 @@ class DenonAVRDeviceInfo:
             raise AvrCommandError("Quick select number must be between 1 and 5")
 
         if self.telnet_available:
-            if "denon" in self.manufacturer.lower():
+            if self.is_denon_avr:
                 command = self.telnet_commands.command_quick_select_mode
             else:
                 command = self.telnet_commands.command_smart_select_mode
@@ -1434,7 +1504,7 @@ class DenonAVRDeviceInfo:
                 command.format(number=quick_select_number)
             )
         else:
-            if "denon" in self.manufacturer.lower():
+            if self.is_denon_avr:
                 command = self.urls.command_quick_select_memory
             else:
                 command = self.urls.command_smart_select_memory
@@ -1518,11 +1588,17 @@ class DenonAVRDeviceInfo:
                 self.urls.command_video_processing_mode.format(mode=processing_mode)
             )
 
-    async def async_status(self) -> str:
+    async def async_status(self) -> None:
         """Get status of receiver via HTTP get command."""
-        if "denon" not in self.manufacturer.lower():
+        if not self.is_denon_avr:
             raise AvrCommandError("Status command is only supported for Denon devices")
-        return await self.api.async_get_command(self.urls.command_status)
+
+        if self.telnet_available:
+            await self.telnet_api.async_send_commands(
+                self.telnet_commands.command_status
+            )
+        else:
+            await self.api.async_get_command(self.urls.command_status)
 
     async def async_system_reset(self) -> None:
         """DANGER! Reset the receiver via HTTP get command."""
@@ -1811,6 +1887,108 @@ class DenonAVRDeviceInfo:
             await self.async_headphone_eq_off()
         else:
             await self.async_headphone_eq_on()
+
+    async def async_hdmi_cec_on(self) -> None:
+        """Turn on HDMI CEC on receiver via HTTP get command."""
+        if self.telnet_available:
+            await self.telnet_api.async_send_commands(
+                self.telnet_commands.command_denon_hdmi_cec_on
+                if self.is_denon_avr
+                else self.urls.command_marantz_hdmi_cec_on
+            )
+        else:
+            await self.api.async_get_command(
+                self.urls.command_denon_hdmi_cec_on
+                if self.is_denon_avr
+                else self.urls.command_marantz_hdmi_cec_on
+            )
+
+    async def async_hdmi_cec_off(self) -> None:
+        """Turn off HDMI CEC on receiver via HTTP get command."""
+        if self.telnet_available:
+            await self.telnet_api.async_send_commands(
+                self.telnet_commands.command_denon_hdmi_cec_off
+                if self.is_denon_avr
+                else self.urls.command_marantz_hdmi_cec_off
+            )
+        else:
+            await self.api.async_get_command(
+                self.urls.command_denon_hdmi_cec_off
+                if self.is_denon_avr
+                else self.urls.command_marantz_hdmi_cec_off
+            )
+
+    async def async_illumination(self, mode: Illuminations):
+        """
+        Set illumination mode on receiver via HTTP get command.
+
+        Only available on Marantz devices.
+        """
+        if self.is_denon_avr:
+            raise AvrCommandError("Illumination is only available for Marantz devices")
+
+        if mode not in self._illuminations:
+            raise AvrCommandError("Invalid illumination mode")
+
+        mapped_mode = ILLUMINATION_MAP[mode]
+        if self.telnet_available:
+            await self.telnet_api.async_send_commands(
+                self.telnet_commands.command_illumination.format(mode=mapped_mode)
+            )
+        else:
+            await self.api.async_get_command(
+                self.urls.command_illumination.format(mode=mapped_mode)
+            )
+
+    async def async_auto_lip_sync_on(self) -> None:
+        """
+        Turn on auto lip sync on receiver via HTTP get command.
+
+        Only available on Marantz devices.
+        """
+        if self.is_denon_avr:
+            raise AvrCommandError("Auto lip sync is only available for Marantz devices")
+
+        if self.telnet_available:
+            await self.telnet_api.async_send_commands(
+                self.telnet_commands.command_auto_lip_sync.format(mode="ON")
+            )
+        else:
+            await self.api.async_get_command(
+                self.urls.command_auto_lip_sync.format(mode="ON")
+            )
+
+    async def async_auto_lip_sync_off(self) -> None:
+        """
+        Turn off auto lip sync on receiver via HTTP get command.
+
+        Only available on Marantz devices.
+        """
+        if self.is_denon_avr:
+            raise AvrCommandError("Auto lip sync is only available for Marantz devices")
+
+        if self.telnet_available:
+            await self.telnet_api.async_send_commands(
+                self.telnet_commands.command_auto_lip_sync.format(mode="OFF")
+            )
+        else:
+            await self.api.async_get_command(
+                self.urls.command_auto_lip_sync.format(mode="OFF")
+            )
+
+    async def async_auto_lip_sync_toggle(self) -> None:
+        """
+        Toggle auto lip sync on receiver via HTTP get command.
+
+        Only available on Marantz devices and when using Telnet.
+        """
+        if self.is_denon_avr:
+            raise AvrCommandError("Auto lip sync is only available for Marantz devices")
+
+        if self._auto_lip_sync:
+            await self.async_auto_lip_sync_off()
+        else:
+            await self.async_auto_lip_sync_on()
 
 
 @attr.s(auto_attribs=True, on_setattr=DENON_ATTR_SETATTR)

--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -233,7 +233,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
             )
             self._device.telnet_api.register_callback("PS", self._async_drc_callback)
 
-            if not self._device.is_denon_avr:
+            if not self._device.is_denon:
                 self._device.telnet_api.register_callback(
                     "PS", self._async_mdax_callback
                 )
@@ -1295,7 +1295,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
 
         Only available for Marantz devices.
         """
-        if self._device.is_denon_avr:
+        if self._device.is_denon:
             raise AvrCommandError("M-DAX is only available for Marantz devices")
 
         if mode not in self._mdaxs:
@@ -1317,7 +1317,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
 
         Only available for Marantz devices.
         """
-        if self._device.is_denon_avr:
+        if self._device.is_denon:
             raise AvrCommandError("DAC Filter is only available for Marantz devices")
 
         if mode not in self._dac_filters:


### PR DESCRIPTION
New commands:
- HDMI CEC on/off
- M-DAX (Marantz only)
- DAC Filter (Marantz only)
- Illumination (Marantz only)
- Auto Lip Sync (Marantz only)

Also use Telnet API for status command