### PR TITLE
Group callbacks by event type to improve performance

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -165,12 +165,12 @@ class DenonAVR(DenonAVRFoundation):
                 self._name = self._device.friendly_name
 
             # Setup other functions
-            self.input.setup()
+            await self.input.async_setup()
             await self.soundmode.async_setup()
             await self.tonecontrol.async_setup()
-            self.vol.setup()
-            self.audyssey.setup()
-            self.dirac.setup()
+            await self.vol.async_setup()
+            await self.audyssey.async_setup()
+            await self.dirac.async_setup()
 
             for zone_name, zone_item in self._zones.items():
                 if zone_name != self.zone:

--- a/denonavr/input.py
+++ b/denonavr/input.py
@@ -181,7 +181,7 @@ class DenonAVRInput(DenonAVRFoundation):
     # Status.xml interface
     status_xml_attrs = {"_input_func": "./InputFuncSelect/value"}
 
-    def setup(self) -> None:
+    async def async_setup(self) -> None:
         """Ensure that the instance is initialized."""
         # Add tags for a potential AppCommand.xml update
         # For update of input function list
@@ -192,6 +192,11 @@ class DenonAVRInput(DenonAVRFoundation):
         for tag in self.appcommand_attrs:
             self._device.api.add_appcommand_update_tag(tag)
 
+        asyncio.create_task(self._async_register_input_callbacks())
+
+        self._is_setup = True
+
+    async def _async_register_input_callbacks(self) -> None:
         power_event = "ZM"
         if self._device.zone == ZONE2:
             power_event = "Z2"
@@ -207,8 +212,6 @@ class DenonAVRInput(DenonAVRFoundation):
         self._device.telnet_api.register_callback(
             "SS", self._async_input_func_update_callback
         )
-
-        self._is_setup = True
 
     async def _async_input_callback(
         self, zone: str, event: str, parameter: str
@@ -417,7 +420,7 @@ class DenonAVRInput(DenonAVRFoundation):
         _LOGGER.debug("Starting input update")
         # Ensure instance is setup before updating
         if not self._is_setup:
-            self.setup()
+            await self.async_setup()
 
         # Update input functions
         _LOGGER.debug("Updating input functions")

--- a/denonavr/soundmode.py
+++ b/denonavr/soundmode.py
@@ -188,39 +188,13 @@ class DenonAVRSoundMode(DenonAVRFoundation):
                 for tag in self.appcommand_attrs:
                     self._device.api.add_appcommand_update_tag(tag)
 
-            self._device.telnet_api.register_callback(
-                "MS", self._async_soundmode_callback
-            )
-            self._device.telnet_api.register_callback(
-                "PS", self._async_neural_x_callback
-            )
-            self._device.telnet_api.register_callback("PS", self._async_imax_callback)
-            self._device.telnet_api.register_callback(
-                "PS", self._async_cinema_eq_callback
-            )
-            self._device.telnet_api.register_callback(
-                "PS", self._async_center_spread_callback
-            )
-            self._device.telnet_api.register_callback(
-                "PS", self._async_loudness_management_callback
-            )
-            self._device.telnet_api.register_callback(
-                "PS", self._async_dialog_enhancer_callback
-            )
-            self._device.telnet_api.register_callback("PS", self._async_auro_callback)
-            self._device.telnet_api.register_callback(
-                "PS", self._async_dialog_control_callback
-            )
-            self._device.telnet_api.register_callback(
-                "PS", self._async_speaker_virtualizer_callback
-            )
-            self._device.telnet_api.register_callback(
-                "PS", self._async_effect_speaker_selection_callback
-            )
-            self._device.telnet_api.register_callback("PS", self._async_drc_callback)
+            asyncio.create_task(self._async_register_callbacks())
 
             self._is_setup = True
-            _LOGGER.debug("Finished sound mode setup")
+
+    async def _async_register_callbacks(self) -> None:
+        self._device.telnet_api.register_callback("MS", self._async_soundmode_callback)
+        self._device.telnet_api.register_callback("PS", self._async_ps_callback)
 
     async def _async_soundmode_callback(
         self, zone: str, event: str, parameter: str
@@ -235,15 +209,27 @@ class DenonAVRSoundMode(DenonAVRFoundation):
 
         self._sound_mode_raw = parameter
 
-    async def _async_neural_x_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
+    async def _async_ps_callback(self, zone: str, event: str, parameter: str) -> None:
+        """Handle a PS change event."""
+        await self._async_neural_x_callback(parameter)
+        await self._async_imax_callback(parameter)
+        await self._async_cinema_eq_callback(parameter)
+        await self._async_center_spread_callback(parameter)
+        await self._async_loudness_management_callback(parameter)
+        await self._async_dialog_enhancer_callback(parameter)
+        await self._async_auro_callback(parameter)
+        await self._async_dialog_control_callback(parameter)
+        await self._async_speaker_virtualizer_callback(parameter)
+        await self._async_effect_speaker_selection_callback(parameter)
+        await self._async_drc_callback(parameter)
+
+    async def _async_neural_x_callback(self, parameter: str) -> None:
         """Handle a Neural X:change event."""
         parameter_name_length = len("NEURAL")
         if parameter[:parameter_name_length] == "NEURAL":
             self._neural_x = parameter[parameter_name_length + 1 :]
 
-    async def _async_imax_callback(self, zone: str, event: str, parameter: str) -> None:
+    async def _async_imax_callback(self, parameter: str) -> None:
         """Handle an IMAX change event."""
         key_value = parameter.split()
         if len(key_value) != 2 or key_value[0][:4] != "IMAX":
@@ -262,37 +248,29 @@ class DenonAVRSoundMode(DenonAVRFoundation):
         elif key_value[0] == "IMAXSWO":
             self._imax_subwoofer_output = parameter[8:]
 
-    async def _async_cinema_eq_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
+    async def _async_cinema_eq_callback(self, parameter: str) -> None:
         """Handle a Cinema EQ change event."""
         if parameter[:10] == "CINEMA EQ.":
             self._cinema_eq = parameter[10:]
 
-    async def _async_center_spread_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
+    async def _async_center_spread_callback(self, parameter: str) -> None:
         """Handle a Center Spread change event."""
         if parameter[:3] == "CES":
             self._center_spread = parameter[4:]
 
-    async def _async_loudness_management_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
+    async def _async_loudness_management_callback(self, parameter: str) -> None:
         """Handle a Loudness Management change event."""
         if parameter[:3] == "LOM":
             self._loudness_management = parameter[4:]
 
-    async def _async_dialog_enhancer_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
+    async def _async_dialog_enhancer_callback(self, parameter: str) -> None:
         """Handle a Dialog Enhancer change event."""
         if parameter[:3] == "DEH":
             self._dialog_enhancer_level = DIALOG_ENHANCER_LEVEL_MAP_LABELS[
                 parameter[4:]
             ]
 
-    async def _async_auro_callback(self, zone: str, event: str, parameter: str) -> None:
+    async def _async_auro_callback(self, parameter: str) -> None:
         """Handle a Auro change event."""
         key_value = parameter.split()
         if len(key_value) != 2 or key_value[0][:4] != "AURO":
@@ -305,9 +283,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
         elif key_value[0] == "AUROMODE":
             self._auro_3d_mode = AURO_3D_MODE_MAP_MAP_LABELS[parameter[9:]]
 
-    async def _async_dialog_control_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
+    async def _async_dialog_control_callback(self, parameter: str) -> None:
         """Handle a Dialog Control change event."""
         key_value = parameter.split()
         if len(key_value) != 2 or key_value[0] != "DIC":
@@ -315,9 +291,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
 
         self._dialog_control = int(key_value[1])
 
-    async def _async_speaker_virtualizer_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
+    async def _async_speaker_virtualizer_callback(self, parameter: str) -> None:
         """Handle a Speaker Virtualizer change event."""
         key_value = parameter.split()
         if len(key_value) != 2 or key_value[0] != "SPV":
@@ -325,9 +299,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
 
         self._speaker_virtualizer = key_value[1]
 
-    async def _async_effect_speaker_selection_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
+    async def _async_effect_speaker_selection_callback(self, parameter: str) -> None:
         """Handle a Effect Speaker Selection change event."""
         key_value = parameter.split(":")
         if len(key_value) != 2 or key_value[0] != "SP":
@@ -337,7 +309,7 @@ class DenonAVRSoundMode(DenonAVRFoundation):
             key_value[1]
         ]
 
-    async def _async_drc_callback(self, zone: str, event: str, parameter: str) -> None:
+    async def _async_drc_callback(self, parameter: str) -> None:
         """Handle a DRC change event."""
         key_value = parameter.split()
         if len(key_value) != 2 or key_value[0] != "DRC":

--- a/denonavr/tonecontrol.py
+++ b/denonavr/tonecontrol.py
@@ -67,17 +67,16 @@ class DenonAVRToneControl(DenonAVRFoundation):
                 for tag in self.appcommand_attrs:
                     self._device.api.add_appcommand_update_tag(tag)
 
-            self._device.telnet_api.register_callback(
-                "PS", self._async_sound_detail_callback
-            )
+            asyncio.create_task(self._async_register_tone_control_callbacks())
 
             self._is_setup = True
             _LOGGER.debug("Finished tone control setup")
 
-    async def _async_sound_detail_callback(
-        self, zone: str, event: str, parameter: str
-    ) -> None:
-        """Handle a sound detail change event."""
+    async def _async_register_tone_control_callbacks(self) -> None:
+        self._device.telnet_api.register_callback("PS", self._async_ps_callback)
+
+    async def _async_ps_callback(self, zone: str, event: str, parameter: str) -> None:
+        """Handle a PS change event."""
         if self._device.zone != zone:
             return
 


### PR DESCRIPTION
Reduce the number of callbacks as well as make them register async to improve startup time on weaker hardware where it can take several seconds.

This reduces the number of callbacks from 49 to 22.