### PR TITLE
Fix quick/smart select mode/memory mix-up

### DIFF
--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -1403,9 +1403,9 @@ class DenonAVRDeviceInfo:
 
         if self.telnet_available:
             if "denon" in self.manufacturer.lower():
-                command = self.telnet_commands.command_quick_select_memory
+                command = self.telnet_commands.command_quick_select_mode
             else:
-                command = self.telnet_commands.command_smart_select_memory
+                command = self.telnet_commands.command_smart_select_mode
             await self.telnet_api.async_send_commands(
                 command.format(number=quick_select_number)
             )
@@ -1427,9 +1427,9 @@ class DenonAVRDeviceInfo:
 
         if self.telnet_available:
             if "denon" in self.manufacturer.lower():
-                command = self.telnet_commands.command_quick_select_mode
+                command = self.telnet_commands.command_quick_select_memory
             else:
-                command = self.telnet_commands.command_smart_select_mode
+                command = self.telnet_commands.command_smart_select_memory
             await self.telnet_api.async_send_commands(
                 command.format(number=quick_select_number)
             )


### PR DESCRIPTION
The mode and memory commands uses mixed up constants when using telnet.