### PR TITLE
Add hdmiout on http

### DIFF
--- a/denonavr/appcommand.py
+++ b/denonavr/appcommand.py
@@ -145,6 +145,27 @@ class AppCommands:
         ),
     )
 
+    GetOutputSettings = AppCommandCmd(
+        cmd_id="3",
+        name="GetOutputSettings",
+        param_list=(
+            AppCommandCmdParam(name="videoout"),
+        ),
+        response_pattern=(
+            AppCommandResponsePattern(
+                update_attribute="_videoout",
+                add_zone=False,
+                suffix="/list/param[@name='videoout']",
+            ),
+        )
+    )
+    SetOutputSettingsVideoOut = AppCommandCmd(
+        cmd_id="3",
+        name="SetOutputSettings",
+        param_list=(AppCommandCmdParam(name="videoout", text="REPLACE"),),
+    )
+
+
     GetSurroundModeStatus = AppCommandCmd(
         cmd_id="1",
         cmd_text="GetSurroundModeStatus",

--- a/denonavr/appcommand.py
+++ b/denonavr/appcommand.py
@@ -148,23 +148,20 @@ class AppCommands:
     GetOutputSettings = AppCommandCmd(
         cmd_id="3",
         name="GetOutputSettings",
-        param_list=(
-            AppCommandCmdParam(name="videoout"),
-        ),
+        param_list=(AppCommandCmdParam(name="videoout"),),
         response_pattern=(
             AppCommandResponsePattern(
                 update_attribute="_videoout",
                 add_zone=False,
                 suffix="/list/param[@name='videoout']",
             ),
-        )
+        ),
     )
     SetOutputSettingsVideoOut = AppCommandCmd(
         cmd_id="3",
         name="SetOutputSettings",
         param_list=(AppCommandCmdParam(name="videoout", text="REPLACE"),),
     )
-
 
     GetSurroundModeStatus = AppCommandCmd(
         cmd_id="1",

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -1760,16 +1760,25 @@ EFFECT_SPEAKER_SELECTION_MAP_REVERSE = {
 DRCs = Literal["AUTO", "LOW", "MID", "HI", "OFF"]
 """Dynamic Range Control (DRC) Settings."""
 
-HDMI_OUTPUT_MAP = {
+HDMI_OUTPUT_MAP_APPCOMMAND = {
+    "3": "Auto",
+    "1": "HDMI1",
+    "2": "HDMI2",
+}
+HDMI_OUTPUT_MAP_TELNET = {
     "MONIAUTO": "Auto",
     "MONI1": "HDMI1",
     "MONI2": "HDMI2",
 }
-HDMI_OUTPUT_MAP_REVERSE = {
+HDMI_OUTPUT_MAP_TELNET_REVERSE = {
     "Auto": "AUTO",
     "HDMI1": "1",
     "HDMI2": "2",
 }
+HDMI_OUTPUT_MAP_APPCOMMAND_REVERSE = {
+    value: key for key, value in HDMI_OUTPUT_MAP_APPCOMMAND.items()
+}
+HDMI_OUTPUT_MAP = {**HDMI_OUTPUT_MAP_APPCOMMAND, **HDMI_OUTPUT_MAP_TELNET}
 
 HDMIOutputs = Literal["Auto", "HDMI1", "HDMI2"]
 """HDMI Output Modes."""

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -216,7 +216,9 @@ class DenonAVR(DenonAVRFoundation):
             await self.soundmode.async_update(global_update=True, cache_id=cache_id)
             await self.tonecontrol.async_update(global_update=True, cache_id=cache_id)
             await self.vol.async_update(global_update=True, cache_id=cache_id)
-            await self.outputsettings.async_update(global_update=True, cache_id=cache_id)
+            await self.outputsettings.async_update(
+                global_update=True, cache_id=cache_id
+            )
         except AvrForbiddenError:
             # Recovery in case receiver changes port from 80 to 8080 which
             # might happen at Denon AVR-X 2016 receivers

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -42,6 +42,7 @@ from .dirac import DenonAVRDirac, dirac_factory
 from .exceptions import AvrCommandError, AvrForbiddenError, AvrIncompleteResponseError
 from .foundation import DenonAVRFoundation, set_api_host, set_api_timeout
 from .input import DenonAVRInput, input_factory
+from .outputsettings import DenonAVROutputSettings, outputsettings_factory
 from .soundmode import DenonAVRSoundMode, sound_mode_factory
 from .tonecontrol import DenonAVRToneControl, tone_control_factory
 from .volume import DenonAVRVolume, volume_factory
@@ -116,6 +117,11 @@ class DenonAVR(DenonAVRFoundation):
         default=attr.Factory(input_factory, takes_self=True),
         init=False,
     )
+    outputsettings: DenonAVROutputSettings = attr.ib(
+        validator=attr.validators.instance_of(DenonAVROutputSettings),
+        default=attr.Factory(outputsettings_factory, takes_self=True),
+        init=False,
+    )
     soundmode: DenonAVRSoundMode = attr.ib(
         validator=attr.validators.instance_of(DenonAVRSoundMode),
         default=attr.Factory(sound_mode_factory, takes_self=True),
@@ -178,6 +184,7 @@ class DenonAVR(DenonAVRFoundation):
             self.vol.setup()
             self.audyssey.setup()
             self.dirac.setup()
+            self.outputsettings.setup()
 
             for zone_name, zone_item in self._zones.items():
                 if zone_name != self.zone:
@@ -209,6 +216,7 @@ class DenonAVR(DenonAVRFoundation):
             await self.soundmode.async_update(global_update=True, cache_id=cache_id)
             await self.tonecontrol.async_update(global_update=True, cache_id=cache_id)
             await self.vol.async_update(global_update=True, cache_id=cache_id)
+            await self.outputsettings.async_update(global_update=True, cache_id=cache_id)
         except AvrForbiddenError:
             # Recovery in case receiver changes port from 80 to 8080 which
             # might happen at Denon AVR-X 2016 receivers
@@ -616,11 +624,9 @@ class DenonAVR(DenonAVRFoundation):
         """
         Returns the HDMI-output for the device.
 
-        Only available if using Telnet.
-
         Possible values are: "Auto", "HDMI1", "HDMI2"
         """
-        return self._device.hdmi_output
+        return self.outputsettings.videoout
 
     @property
     def hdmi_audio_decode(self) -> Optional[str]:
@@ -1045,7 +1051,7 @@ class DenonAVR(DenonAVRFoundation):
 
     async def async_hdmi_output(self, output: HDMIOutputs) -> None:
         """Set HDMI output."""
-        await self._device.async_hdmi_output(output)
+        await self.outputsettings.async_set_videoout(output)
 
     async def async_hdmi_audio_decode(self, mode: HDMIAudioDecodes) -> None:
         """Set HDMI Audio Decode mode on receiver."""

--- a/denonavr/foundation.py
+++ b/denonavr/foundation.py
@@ -63,7 +63,6 @@ from .const import (
     DimmerModes,
     EcoModes,
     HDMIAudioDecodes,
-    HDMIOutputs,
     Illuminations,
     InputModes,
     PanelLocks,

--- a/denonavr/outputsettings.py
+++ b/denonavr/outputsettings.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module implements the Output settings of Denon AVR receivers.
+
+:copyright: (c) 2020 by Oliver Goetz.
+:license: MIT, see LICENSE for more details.
+"""
+
+import logging
+from collections.abc import Hashable
+from typing import Optional
+
+import attr
+
+from .appcommand import AppCommandCmd, AppCommandCmdParam, AppCommands
+from .const import (
+    DENON_ATTR_SETATTR,
+    HDMI_OUTPUT_MAP,
+    HDMI_OUTPUT_MAP_APPCOMMAND_REVERSE,
+    HDMI_OUTPUT_MAP_TELNET_REVERSE,
+    HDMIOutputs,
+)
+from .exceptions import AvrCommandError, AvrProcessingError
+from .foundation import DenonAVRFoundation
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True, on_setattr=DENON_ATTR_SETATTR)
+class DenonAVROutputSettings(DenonAVRFoundation):
+    """Output Settings."""
+
+    _videoout: Optional[str] = attr.ib(
+        converter=attr.converters.optional(HDMI_OUTPUT_MAP.get), default=None
+    )
+
+    # Update tags for attributes
+    # AppCommand0300.xml interface
+    appcommand0300_attrs = {AppCommands.GetOutputSettings: None}
+
+    def setup(self) -> None:
+        """Ensure that the instance is initialized."""
+        # Add tags for a potential AppCommand.xml update
+        for tag in self.appcommand0300_attrs:
+            self._device.api.add_appcommand0300_update_tag(tag)
+
+        self._device.telnet_api.register_callback("VS", self._videoout_callback)
+
+        self._is_setup = True
+
+    def _videoout_callback(self, zone: str, event: str, parameter: str) -> None:
+        """Handle a HDMI Output change event."""
+        if self._device.zone != zone:
+            return
+
+        if parameter[0:4] == "MONI":
+            self._videoout = parameter
+
+    async def async_update(
+        self, global_update: bool = False, cache_id: Optional[Hashable] = None
+    ) -> None:
+        """Update OutputSettings asynchronously."""
+        _LOGGER.debug("Starting OutputSettings update")
+        # Ensure instance is setup before updating
+        if not self._is_setup:
+            self.setup()
+
+        # Update state
+        await self.async_update_outputsettings(global_update=global_update, cache_id=cache_id)
+        _LOGGER.debug("Finished OutputSettings update")
+
+    async def async_update_outputsettings(
+        self, global_update: bool = False, cache_id: Optional[Hashable] = None
+    ):
+        """Update OutputSettings status of device."""
+        if self._device.use_avr_2016_update is None:
+            raise AvrProcessingError(
+                "Device is not setup correctly, update method not set"
+            )
+
+        # OutputSettings is only available for avr 2016 update
+        if self._device.use_avr_2016_update:
+            try:
+                await self.async_update_attrs_appcommand(
+                    self.appcommand0300_attrs,
+                    appcommand0300=True,
+                    global_update=global_update,
+                    cache_id=cache_id,
+                )
+            except AvrProcessingError as err:
+                # Don't raise an error here, because not all devices support it
+                _LOGGER.debug("Updating OutputSettings failed: %s", err)
+
+    async def _async_set_outputsettings(self, cmd: AppCommandCmd) -> None:
+        """Set OutputSettings parameter."""
+        res = await self._device.api.async_post_appcommand(
+            self._device.urls.appcommand0300, (cmd,)
+        )
+
+        try:
+            if res.find("cmd").text != "OK":
+                raise AvrProcessingError(f"SetOutputSettings command {cmd.name} failed")
+        except AttributeError as err:
+            raise AvrProcessingError(f"SetOutputSettings command {cmd.name} failed") from err
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def videoout(self) -> Optional[str]:
+        """Return value of Video Out."""
+        return self._videoout
+
+
+    ##########
+    # Setter #
+    ##########
+
+    async def async_set_videoout(self, value: HDMIOutputs) -> None:
+        """Set Video Out mode."""
+        if self._device.telnet_available:
+            setting = HDMI_OUTPUT_MAP_TELNET_REVERSE.get(value)
+            if setting is None:
+                raise AvrCommandError(f"Value {value} not known for Video Out")
+            telnet_command = self._device.telnet_commands.command_hdmi_output.format(output=setting)
+            await self._device.telnet_api.async_send_commands(telnet_command)
+            return
+
+        setting = HDMI_OUTPUT_MAP_APPCOMMAND_REVERSE.get(value)
+        if setting is None:
+            raise AvrCommandError(f"Value {value} not known for Video Out")
+        cmd = attr.evolve(
+            AppCommands.SetOutputSettingsVideoOut,
+            param_list=(AppCommandCmdParam(name="videoout", text=setting),),
+        )
+        await self._async_set_outputsettings(cmd)
+
+
+
+def outputsettings_factory(instance: DenonAVRFoundation) -> DenonAVROutputSettings:
+    """Create DenonAVROutputSettings at receiver instances."""
+    # pylint: disable=protected-access
+    new = DenonAVROutputSettings(device=instance._device)
+    return new

--- a/denonavr/outputsettings.py
+++ b/denonavr/outputsettings.py
@@ -67,7 +67,9 @@ class DenonAVROutputSettings(DenonAVRFoundation):
             self.setup()
 
         # Update state
-        await self.async_update_outputsettings(global_update=global_update, cache_id=cache_id)
+        await self.async_update_outputsettings(
+            global_update=global_update, cache_id=cache_id
+        )
         _LOGGER.debug("Finished OutputSettings update")
 
     async def async_update_outputsettings(
@@ -102,7 +104,9 @@ class DenonAVROutputSettings(DenonAVRFoundation):
             if res.find("cmd").text != "OK":
                 raise AvrProcessingError(f"SetOutputSettings command {cmd.name} failed")
         except AttributeError as err:
-            raise AvrProcessingError(f"SetOutputSettings command {cmd.name} failed") from err
+            raise AvrProcessingError(
+                f"SetOutputSettings command {cmd.name} failed"
+            ) from err
 
     ##############
     # Properties #
@@ -112,7 +116,6 @@ class DenonAVROutputSettings(DenonAVRFoundation):
     def videoout(self) -> Optional[str]:
         """Return value of Video Out."""
         return self._videoout
-
 
     ##########
     # Setter #
@@ -124,7 +127,9 @@ class DenonAVROutputSettings(DenonAVRFoundation):
             setting = HDMI_OUTPUT_MAP_TELNET_REVERSE.get(value)
             if setting is None:
                 raise AvrCommandError(f"Value {value} not known for Video Out")
-            telnet_command = self._device.telnet_commands.command_hdmi_output.format(output=setting)
+            telnet_command = self._device.telnet_commands.command_hdmi_output.format(
+                output=setting
+            )
             await self._device.telnet_api.async_send_commands(telnet_command)
             return
 
@@ -136,7 +141,6 @@ class DenonAVROutputSettings(DenonAVRFoundation):
             param_list=(AppCommandCmdParam(name="videoout", text=setting),),
         )
         await self._async_set_outputsettings(cmd)
-
 
 
 def outputsettings_factory(instance: DenonAVRFoundation) -> DenonAVROutputSettings:

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -15,7 +15,7 @@ from denonavr.const import (
     DIMMER_MODE_MAP_REVERSE,
     DIRAC_FILTER_MAP_REVERSE,
     ECO_MODE_MAP_REVERSE,
-    HDMI_OUTPUT_MAP_REVERSE,
+    HDMI_OUTPUT_MAP_TELNET_REVERSE,
     Channels,
     DimmerModes,
     DiracFilters,
@@ -40,7 +40,7 @@ class TestMappings(unittest.TestCase):
     def test_hdmi_outputs_mappings(self):
         """Test that all hdmi outputs are in the mapping."""
         for hdmi_output in get_args(HDMIOutputs):
-            self.assertIn(hdmi_output, HDMI_OUTPUT_MAP_REVERSE)
+            self.assertIn(hdmi_output, HDMI_OUTPUT_MAP_TELNET_REVERSE)
 
     def test_channel_mappings(self):
         """Test that all channels are in the mapping."""


### PR DESCRIPTION
This PR add support for HDMI out using the xml api with the goal to later make it available in Home Assistant (it is my current understanding that the XML suppport is needed for that).

I tried to build it in a similar way to how other things are done. I used the naming as used in the XML which is videoout iso hdmiout, but kept the current API the same.

Manual testing with a simple example script seems to indicate it works with my receiver (AVC-X2850H).

However...

Some tests started failing and I don't really understand why.
Also I could not  figure out how these tests work exactly. They seem to use the XML files that are in the `tests/xml` directory, but unclear to me how to update those files and if that should be even needed.

I would appreciate some pointers on how to approach the testing part.