### PR TITLE
Include the request URL in HTTP error messages

### DIFF
--- a/denonavr/decorators.py
+++ b/denonavr/decorators.py
@@ -39,21 +39,29 @@ def async_handle_receiver_exceptions(func: Callable[..., AnyT]) -> Callable[...,
             _LOGGER.debug("HTTP status error on request %s: %s", err.request, err)
             # Separate handling of 403 errors
             if err.response.status_code == 403:
-                raise AvrForbiddenError(f"HTTPStatusError: {err}", err.request) from err
-            raise AvrRequestError(f"HTTPStatusError: {err}", err.request) from err
+                raise AvrForbiddenError(
+                    f"HTTPStatusError for {err.request.url}: {err}", err.request
+                ) from err
+            raise AvrRequestError(
+                f"HTTPStatusError for {err.request.url}: {err}", err.request
+            ) from err
         except httpx.TimeoutException as err:
             _LOGGER.debug("HTTP timeout exception on request %s: %s", err.request, err)
-            raise AvrTimoutError(f"TimeoutException: {err}", err.request) from err
+            raise AvrTimoutError(
+                f"TimeoutException for {err.request.url}: {err}", err.request
+            ) from err
         except httpx.NetworkError as err:
             _LOGGER.debug("Network error exception on request %s: %s", err.request, err)
-            raise AvrNetworkError(f"NetworkError: {err}", err.request) from err
+            raise AvrNetworkError(
+                f"NetworkError for {err.request.url}: {err}", err.request
+            ) from err
         except httpx.RemoteProtocolError as err:
             _LOGGER.debug(
                 "Remote protocol error exception on request %s",
                 err.request,
             )
             raise AvrInvalidResponseError(
-                f"RemoteProtocolError: {err}", err.request
+                f"RemoteProtocolError for {err.request.url}: {err}", err.request
             ) from err
 
     return wrapper

--- a/tests/test_denonavr.py
+++ b/tests/test_denonavr.py
@@ -17,6 +17,7 @@ from pytest_httpx import HTTPXMock
 import denonavr
 from denonavr.api import DenonAVRTelnetApi, DenonAVRTelnetProtocol
 from denonavr.const import SOUND_MODE_MAPPING
+from denonavr.decorators import async_handle_receiver_exceptions
 from denonavr.exceptions import AvrNetworkError, AvrTimoutError
 
 FAKE_IP = "10.0.0.0"
@@ -401,6 +402,36 @@ class TestMainFunctions:
             )
             with pytest.raises(AvrTimoutError):
                 await api.async_connect()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("raised_error", "expected_error"),
+        [
+            (httpx.ConnectError, AvrNetworkError),
+            (httpx.ConnectTimeout, AvrTimoutError),
+        ],
+    )
+    async def test_request_error_message_includes_url(
+        self, raised_error, expected_error
+    ):
+        """Errors raised by the request decorator include the request URL."""
+        url = "http://10.0.0.0:60006/upnp/desc/aios_device/aios_device.xml"
+
+        @async_handle_receiver_exceptions
+        async def failing_request():
+            raise raised_error(
+                "All connection attempts failed",
+                request=httpx.Request("GET", url),
+            )
+
+        with pytest.raises(expected_error) as exc_info:
+            await failing_request()
+
+        # URL must appear in the message so consumers (e.g. Home Assistant)
+        # can tell which endpoint/port was unreachable.
+        assert url in str(exc_info.value)
+        # the original request is still attached for programmatic access
+        assert exc_info.value.request.url == httpx.URL(url)
 
     @pytest.mark.asyncio
     @pytest.mark.httpx_mock(can_send_already_matched_responses=True)


### PR DESCRIPTION
## Summary

Errors raised by `async_handle_receiver_exceptions` now include the failing request URL in their message. Previously only the bare transport error was surfaced, e.g.:

```
NetworkError: All connection attempts failed
```

…with no indication of *which* endpoint or port could not be reached. The URL was already captured in `err.request` (and logged at debug level), but `AvrRequestError` forwards only `message` to `Exception`, so `str(ex)` dropped it. Consumers such as the Home Assistant integration re-raise the error as-is (`raise ConfigEntryNotReady from ex`), so the user never saw the URL.

After this change the message reads e.g.:

```
NetworkError for http://192.168.0.50:60006/upnp/desc/aios_device/aios_device.xml: All connection attempts failed
```

## Motivation / context

While debugging a Marantz NR1508 that had dropped off Home Assistant, the only symptom was `NetworkError: All connection attempts failed`. The actual cause was the receiver's UPnP description service on port `60006` having become unresponsive (the rest of the device was reachable). Diagnosis took far longer than it should have purely because the failing URL — already present on the exception object — was not shown.

Closes #388.

## Changes

- `denonavr/decorators.py`: add `err.request.url` to the message of every error raised in `async_handle_receiver_exceptions` (`AvrForbiddenError`, `AvrRequestError`, `AvrTimoutError`, `AvrNetworkError`,   `AvrInvalidResponseError`). The `request` object stays attached unchanged.
- `tests/test_denonavr.py`: new parametrized test asserting the URL appears in `str(ex)` for the network-error and timeout paths, and that the request object is still exposed.

## Testing

```
$ pytest tests/
37 passed
```

## Notes

- No public API change: only message text is enriched; the second positional `request` argument and the `.request` attribute are unchanged.
- The pre-existing class-name typo `AvrTimoutError` is intentionally left as-is here to avoid an API-breaking rename in this PR.
