### PR TITLE
Add dedicated mute toggle command

### DIFF
--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -922,6 +922,10 @@ class DenonAVR(DenonAVRFoundation):
         """Mute receiver."""
         await self.vol.async_mute(mute)
 
+    async def async_mute_toggle(self) -> None:
+        """Mute toggle receiver via HTTP get command."""
+        await self.vol.async_mute_toggle()
+
     async def async_enable_tone_control(self) -> None:
         """Enable tone control to change settings like bass or treble."""
         await self.tonecontrol.async_enable_tone_control()

--- a/denonavr/volume.py
+++ b/denonavr/volume.py
@@ -350,6 +350,9 @@ class DenonAVRVolume(DenonAVRFoundation):
     async def async_mute(self, mute: bool) -> None:
         """Mute receiver."""
         if mute:
+            if self._muted:
+                return
+
             if self._device.telnet_available:
                 await self._device.telnet_api.async_send_commands(
                     self._device.telnet_commands.command_mute_on
@@ -359,6 +362,9 @@ class DenonAVRVolume(DenonAVRFoundation):
                     self._device.urls.command_mute_on
                 )
         else:
+            if self._muted is False:
+                return
+
             if self._device.telnet_available:
                 await self._device.telnet_api.async_send_commands(
                     self._device.telnet_commands.command_mute_off
@@ -366,6 +372,27 @@ class DenonAVRVolume(DenonAVRFoundation):
             else:
                 await self._device.api.async_get_command(
                     self._device.urls.command_mute_off
+                )
+
+    async def async_mute_toggle(self) -> None:
+        """Mute toggle receiver via HTTP get command."""
+        if self._muted:
+            if self._device.telnet_available:
+                await self._device.telnet_api.async_send_commands(
+                    self._device.telnet_commands.command_mute_off
+                )
+            else:
+                await self._device.api.async_get_command(
+                    self._device.urls.command_mute_off
+                )
+        else:
+            if self._device.telnet_available:
+                await self._device.telnet_api.async_send_commands(
+                    self._device.telnet_commands.command_mute_on
+                )
+            else:
+                await self._device.api.async_get_command(
+                    self._device.urls.command_mute_on
                 )
 
     async def async_channel_volume_up(self, channel: Channels) -> None:


### PR DESCRIPTION
Adds async_mute_toggle to toggle mute state, works over both HTTP and telnet, plus a guard on the regular mute setter.

Relates to #375