### PR TITLE
Correct Bass Sync range to 0-16

### DIFF
--- a/denonavr/volume.py
+++ b/denonavr/volume.py
@@ -164,11 +164,11 @@ class DenonAVRVolume(DenonAVRFoundation):
         self._lfe = int(parameter[4:]) * -1
 
     def _bass_sync_callback(self, zone: str, event: str, parameter: str) -> None:
-        """Handle a LFE change event."""
+        """Handle a Bass Sync change event."""
         if parameter[:3] != "BSC":
             return
 
-        self._bass_sync = int(parameter[4:]) * -1
+        self._bass_sync = parameter[4:]
 
     async def async_update(
         self, global_update: bool = False, cache_id: Optional[Hashable] = None
@@ -571,16 +571,16 @@ class DenonAVRVolume(DenonAVRFoundation):
                 self._device.urls.command_bass_sync.format(mode="DOWN")
             )
 
-    async def async_bass_sync(self, lfe: int) -> None:
+    async def async_bass_sync(self, bass_sync: int) -> None:
         """
         Set Bass Sync level on receiver.
 
-        :param lfe: Bass Sync level to set. Valid values are -10 to 0.
+        :param bass_sync: Bass Sync level to set. Valid values are 0 to 16.
         """
-        if lfe < -10 or lfe > 0:
-            raise AvrCommandError(f"Invalid Bass Sync: {lfe}")
+        if bass_sync < 0 or bass_sync > 16:
+            raise AvrCommandError(f"Invalid Bass Sync: {bass_sync}")
 
-        bass_sync_local = str(lfe).replace("-", "").zfill(2)
+        bass_sync_local = str(bass_sync).zfill(2)
         if self._device.telnet_available:
             await self._device.telnet_api.async_send_commands(
                 self._device.telnet_commands.command_bass_sync.format(


### PR DESCRIPTION
The receiver reports and accepts Bass Sync levels in the range 0 to 16, not -10 to 0. Store the reported value as-is (previously negated) and validate the setter against 0-16.

Relates to #375