### PR TITLE
Fix volume parsing range and add custom max-volume event

### DIFF
--- a/denonavr/api.py
+++ b/denonavr/api.py
@@ -803,11 +803,10 @@ class DenonAVRTelnetApi:
         parameter = message[len(event) :]
 
         if event == "MV":
-            # This seems undocumented by Denon and appears to basically be a
-            # noop that goes along with volume changes. This is here to prevent
-            # duplicate callback calls.
+            # Handle undocumented max volume event:
+            # propagate as a custom event for DenonAVRVolume
             if parameter[0:3] == "MAX":
-                return
+                event = "CUST_MAX_VOL"
 
         # Determine zone
         zone = MAIN_ZONE

--- a/denonavr/const.py
+++ b/denonavr/const.py
@@ -1120,6 +1120,7 @@ ZONE3_URLS = ReceiverURLs(
 ALL_TELNET_EVENTS = "ALL"
 TELNET_EVENTS = {
     "BT",
+    "CUST_MAX_VOL",  # Custom event for separating volume from max volume
     "CV",
     "DC",
     "DIM",

--- a/denonavr/volume.py
+++ b/denonavr/volume.py
@@ -38,17 +38,40 @@ def convert_muted(value: str) -> bool:
     return bool(value.lower() == STATE_ON)
 
 
-def convert_volume(value: Union[float, str]) -> float:
+def convert_volume(value: str) -> float:
     """Convert volume to float."""
-    if value == "--":
+    if value is None or value == "--":
         return -80.0
-    return float(value)
+
+    value = value.strip()
+    if value.startswith("-"):
+        return float(value)
+
+    if len(value) > 3:
+        _LOGGER.warning(
+            "Volume value length is invalid: %s, defaulting to -80.0 dB", value
+        )
+        return -80.0
+
+    if len(value) < 3:
+        value = -80.0 + float(value)
+    else:
+        value = float(value[:2] + "." + value[2]) - 80.0
+
+    if value < -80.0 or value > 18.0:
+        _LOGGER.warning(
+            "Volume %s converted to %s is out of range. Will use clamping.",
+            value,
+            value,
+        )
+    return max(min(value, 18.0), -80.0)
 
 
 @attr.s(auto_attribs=True, on_setattr=DENON_ATTR_SETATTR)
 class DenonAVRVolume(DenonAVRFoundation):
     """This class implements volume functions of Denon AVR receiver."""
 
+    _max_volume: Optional[float] = attr.ib(default=None)
     _volume: Optional[float] = attr.ib(
         converter=attr.converters.optional(convert_volume), default=None
     )
@@ -83,6 +106,9 @@ class DenonAVRVolume(DenonAVRFoundation):
             self._device.api.add_appcommand_update_tag(tag)
 
         self._device.telnet_api.register_callback("MV", self._volume_callback)
+        self._device.telnet_api.register_callback(
+            "CUST_MAX_VOL", self._max_volume_callback
+        )
         self._device.telnet_api.register_callback("MU", self._mute_callback)
         self._device.telnet_api.register_callback("CV", self._channel_volume_callback)
         self._device.telnet_api.register_callback("PS", self._subwoofer_state_callback)
@@ -92,17 +118,34 @@ class DenonAVRVolume(DenonAVRFoundation):
 
         self._is_setup = True
 
-    def _volume_callback(self, zone: str, event: str, parameter: str) -> None:
+    def _volume_callback(self, zone: str, _event: str, parameter: str) -> None:
         """Handle a volume change event."""
         if self._device.zone != zone:
             return
 
-        if len(parameter) < 3:
-            self._volume = -80.0 + float(parameter)
-        else:
-            whole_number = float(parameter[0:2])
-            fraction = 0.1 * float(parameter[2])
-            self._volume = -80.0 + whole_number + fraction
+        self._volume = parameter
+
+    def _max_volume_callback(self, zone: str, _event: str, parameter: str) -> None:
+        """Handle a max volume change event."""
+        if self._device.zone != zone:
+            _LOGGER.info(
+                "Max volume zone mismatch: expected %s, got %s", self._device.zone, zone
+            )
+            return
+
+        if not parameter.startswith("MAX"):
+            _LOGGER.info("Ignoring invalid max volume parameter: %s", parameter)
+            return
+
+        volume = convert_volume(parameter[4:])
+        if volume == -80.0:
+            # -80.0 indicates error with parsing max volume, minimum allowed is -40.0
+            # Set a reasonable default
+            volume = -20.0
+
+        if self._max_volume != volume:
+            self._max_volume = volume
+            _LOGGER.debug("Set max volume: %s", self._max_volume)
 
     def _mute_callback(self, zone: str, event: str, parameter: str) -> None:
         """Handle a muting change event."""
@@ -227,6 +270,15 @@ class DenonAVRVolume(DenonAVRFoundation):
         return self._volume
 
     @property
+    def max_volume(self) -> float:
+        """
+        Return maximum allowed volume of Denon AVR as float.
+
+        Volume is sent in a format like -50.0.
+        """
+        return self._max_volume if self._max_volume is not None else 18.0
+
+    @property
     def channel_volumes(self) -> Optional[Dict[Channels, float]]:
         """
         Return the channel levels of the device in dB.
@@ -304,6 +356,9 @@ class DenonAVRVolume(DenonAVRFoundation):
     ##########
     async def async_volume_up(self) -> None:
         """Volume up receiver."""
+        if self._max_volume and self._volume and self._volume >= self._max_volume:
+            _LOGGER.debug("Volume already at max value, skipping.")
+            return
         if self._device.telnet_available:
             await self._device.telnet_api.async_send_commands(
                 self._device.telnet_commands.command_volume_up, skip_confirmation=True
@@ -331,6 +386,14 @@ class DenonAVRVolume(DenonAVRFoundation):
         Volume is send in a format like -50.0.
         Minimum is -80.0, maximum at 18.0
         """
+        if self._max_volume and volume > self._max_volume:
+            _LOGGER.debug(
+                "Volume %s exceeds custom max volume %s. Setting volume to max allowed",
+                volume,
+                self._max_volume,
+            )
+            volume = self._max_volume
+
         if volume < -80 or volume > 18:
             raise AvrCommandError(f"Invalid volume: {volume}")
 


### PR DESCRIPTION
Volume parsing:
- Rewrite convert_volume to parse the telnet 2/3-digit format directly, handle None/invalid lengths, and clamp the result to [-80.0, 18.0] dB so volume can no longer go out of range.
- Simplify _volume_callback to defer parsing to the attr converter.

Custom max-volume event:
- The receiver sends an undocumented MVMAX event that was previously discarded. Propagate it as a dedicated CUST_MAX_VOL (name can be discussed) telnet event and track the receiver's maximum allowed volume (_max_volume, max_volume property).
- Clamp async_set_volume to the max and skip async_volume_up once the max is reached, which otherwise makes the receiver stop responding and time out.

Relates to #375