### PR TITLE
Parallelize component setup and update

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     name: Testing Python ${{ matrix.python-version }}
     steps:

--- a/denonavr/denonavr.py
+++ b/denonavr/denonavr.py
@@ -190,15 +190,16 @@ class DenonAVR(DenonAVRFoundation):
 
             # Setup other functions
             self.input.setup()
-            await self.soundmode.async_setup()
-            await self.tonecontrol.async_setup()
+            async_tasks = [self.soundmode.async_setup(), self.tonecontrol.async_setup()]
+            for zone_name, zone_item in self._zones.items():
+                if zone_name != self.zone:
+                    async_tasks.append(zone_item.async_setup())
+
+            await asyncio.gather(*async_tasks)
+
             self.vol.setup()
             self.audyssey.setup()
             self.dirac.setup()
-
-            for zone_name, zone_item in self._zones.items():
-                if zone_name != self.zone:
-                    await zone_item.async_setup()
 
             self._is_setup = True
             _LOGGER.debug("Finished denonavr setup")
@@ -222,10 +223,12 @@ class DenonAVR(DenonAVRFoundation):
             await self._device.async_update(global_update=True, cache_id=cache_id)
 
             # Update other functions
-            await self.input.async_update(global_update=True, cache_id=cache_id)
-            await self.soundmode.async_update(global_update=True, cache_id=cache_id)
-            await self.tonecontrol.async_update(global_update=True, cache_id=cache_id)
-            await self.vol.async_update(global_update=True, cache_id=cache_id)
+            await asyncio.gather(
+                self.input.async_update(global_update=True, cache_id=cache_id),
+                self.soundmode.async_update(global_update=True, cache_id=cache_id),
+                self.tonecontrol.async_update(global_update=True, cache_id=cache_id),
+                self.vol.async_update(global_update=True, cache_id=cache_id),
+            )
         except AvrForbiddenError:
             # Recovery in case receiver changes port from 80 to 8080 which
             # might happen at Denon AVR-X 2016 receivers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,13 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
     "Topic :: Home Automation",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "asyncstdlib>=3.10.2",
     "attrs>=21.2.0",


### PR DESCRIPTION
Run the per-component async setup (soundmode, tonecontrol, additional zones) and the per-component async update (input, soundmode, tonecontrol, volume) concurrently with asyncio.gather instead of sequentially, reducing setup and update latency.

Relates to #375